### PR TITLE
Store Entity 생성 (#9)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '6.4.1.Final'	//Geometry 사용을 위해 추가
 }
 
 tasks.named('test') {

--- a/src/main/java/com/nainga/nainga/domain/store/domain/Store.java
+++ b/src/main/java/com/nainga/nainga/domain/store/domain/Store.java
@@ -1,9 +1,6 @@
 package com.nainga.nainga.domain.store.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -13,7 +10,9 @@ import lombok.*;
 @AllArgsConstructor
 public class Store {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    //Hibernate 버전 5이상이 되면서 @GeneratedValue의 Defualt strategy인 Auto가 MySQL에 대해 Table 전략을 사용하므로
+    //이를 보편적인 IDENTITY로 명시적으로 변환 시켜주기 위함. Table 전략을 사용하게 되면 Sequence를 모방하기 위해 seq 테이블이 별도로 추가 생성됨.
     @Column(name = "store_id")
     private Long id;
     private String name;    //가게 이름

--- a/src/main/java/com/nainga/nainga/domain/store/domain/Store.java
+++ b/src/main/java/com/nainga/nainga/domain/store/domain/Store.java
@@ -1,0 +1,26 @@
+package com.nainga.nainga.domain.store.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder    //필드 명시를 통한 가독성 향상을 위해 생성자 대신 빌더 패턴을 적용
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Store {
+
+    @Id @GeneratedValue
+    @Column(name = "store_id")
+    private Long id;
+    private String name;    //가게 이름
+    private String primaryType;    //가게 업종
+    private String formattedAddress;    //가게 전체 주소
+    private String regularOpeningHours;    //영업 시간
+    private String internationalPhoneNumber;    //국제 전화번호
+//    private String location;    //(위도, 경도) 좌표
+//    private String photos;    //가게 사진들
+}

--- a/src/main/java/com/nainga/nainga/domain/store/domain/Store.java
+++ b/src/main/java/com/nainga/nainga/domain/store/domain/Store.java
@@ -2,6 +2,7 @@ package com.nainga.nainga.domain.store.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.locationtech.jts.geom.Point;
 
 @Entity
 @Getter
@@ -20,6 +21,6 @@ public class Store {
     private String formattedAddress;    //가게 전체 주소
     private String regularOpeningHours;    //영업 시간
     private String internationalPhoneNumber;    //국제 전화번호
-//    private String location;    //(위도, 경도) 좌표
+    private Point location;    //(위도, 경도) 좌표
 //    private String photos;    //가게 사진들
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,6 +13,7 @@ spring:
         #          show_sql: true #밑에 org.hivernate.SQL과 겹치는데 얘는 System.out으로 찍는 거고 밑에는 로그로 찍는거. 얘를 안쓰는 걸 추천
         format_sql: true
         default_batch_fetch_size: 1000 # 배치 사이즈 글로벌 적용 (1+n) 문제 해결
+    database-platform: org.hibernate.spatial.dialect.mysql.MySQL56InnoDBSpatialDialect #MySQL에서 Geometry를 사용하기 위해 추가
 
 logging: #로그 레벨을 정하는 것
   level:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,7 +13,6 @@ spring:
         #          show_sql: true #밑에 org.hivernate.SQL과 겹치는데 얘는 System.out으로 찍는 거고 밑에는 로그로 찍는거. 얘를 안쓰는 걸 추천
         format_sql: true
         default_batch_fetch_size: 1000 # 배치 사이즈 글로벌 적용 (1+n) 문제 해결
-    database-platform: org.hibernate.spatial.dialect.mysql.MySQL56InnoDBSpatialDialect #MySQL에서 Geometry를 사용하기 위해 추가
 
 logging: #로그 레벨을 정하는 것
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,8 +3,8 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/nainga?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: #FILL YOUR DATABASE USERNAME
-    password: #FILL YOUR DATABASE PASSWORD
+    username: root #FILL YOUR DATABASE USERNAME
+    password: 1q2w3e4r1! #FILL YOUR DATABASE PASSWORD
   jpa:
     hibernate:
       ddl-auto: create #create로 하면 애플리케이션 실행 시점에 내가 가지고 있는 테이블을 다 지운 다음에 엔티티 정보를 보고 테이블을 자동으로 만들어 줌
@@ -13,6 +13,7 @@ spring:
         #          show_sql: true #밑에 org.hivernate.SQL과 겹치는데 얘는 System.out으로 찍는 거고 밑에는 로그로 찍는거. 얘를 안쓰는 걸 추천
         format_sql: true
         default_batch_fetch_size: 1000 # 배치 사이즈 글로벌 적용 (1+n) 문제 해결
+    database-platform: org.hibernate.spatial.dialect.mysql.MySQL56InnoDBSpatialDialect #MySQL에서 Geometry를 사용하기 위해 추가
 
 logging: #로그 레벨을 정하는 것
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,6 @@ spring:
         #          show_sql: true #밑에 org.hivernate.SQL과 겹치는데 얘는 System.out으로 찍는 거고 밑에는 로그로 찍는거. 얘를 안쓰는 걸 추천
         format_sql: true
         default_batch_fetch_size: 1000 # 배치 사이즈 글로벌 적용 (1+n) 문제 해결
-    database-platform: org.hibernate.spatial.dialect.mysql.MySQL56InnoDBSpatialDialect #MySQL에서 Geometry를 사용하기 위해 추가
 
 logging: #로그 레벨을 정하는 것
   level:


### PR DESCRIPTION
## ⭐️ Issue Number

- #9 

## 🚩 Summary
프로젝트 요구사항에 맞게 Store Entity를 생성합니다. Store Entity에는 가게 이름, 업종, 주소, 영업 시간, (위도 & 경도), 연락처, 가게 사진 등이 들어가게 됩니다. 이때 Spring에서 Geometry 값을 처리할 수 있도록 hibernate-spatial 의존성을 추가해줬습니다.


## 🛠️ Technical Concerns

### @GeneratedValue

JPA의 데이터베이스 기본키 생성 전략은 두가지가 있습니다. 수동과 자동. 저는 @GeneratedValue 애너테이션을 이용해 자동으로 기본키를 생성하도록 지정했는데, 그렇게 한 뒤 생성된 데이터베이스를 보니 Store 테이블 외에도 Store_seq 테이블도 함께 있는 것을 발견하였습니다.

관련해서 찾아보니, @GeneratedValue의 Strategy에는 총 4가지 IDENTITY, TABLE, SEQUENCE, AUTO 이렇게 있었습니다. 이때 
Default strategy는 Auto였고, Auto는 Database dialect에 따라 알아서 strtegy를 적용하는 것을 의미합니다. Hibernate Version 5 이상부터는 MySQL에 대해 Auto가 TABLE 전략을 자동으로 선택한다고 합니다. 그래서 TABLE 전략에 따라 Sequence를 지원하지 않는 MySQL에 Sequence를 모방해서 지원하기 위해 seq table을 만들게 된 것이었습니다.

보편적으로 MySQL에는 IDENTITY 전략을 따르므로, default로 @GeneratedValue(strategy = GenerationType.IDENTITY)을 명시하여 이 문제를 해결해줬습니다.

## 📋 To Do

- Store Entity와 연관 관계를 맺을 Tag Entity를 생성
