### PR TITLE
Tag Entity 생성 (#10)

### DIFF
--- a/src/main/java/com/nainga/nainga/domain/storetag/domain/StoreTag.java
+++ b/src/main/java/com/nainga/nainga/domain/storetag/domain/StoreTag.java
@@ -1,0 +1,24 @@
+package com.nainga.nainga.domain.storetag.domain;
+
+import com.nainga.nainga.domain.store.domain.Store;
+import com.nainga.nainga.domain.tag.domain.Tag;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class StoreTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "store_tag_id")
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id")
+    private Tag tag;
+}

--- a/src/main/java/com/nainga/nainga/domain/tag/domain/Tag.java
+++ b/src/main/java/com/nainga/nainga/domain/tag/domain/Tag.java
@@ -1,0 +1,16 @@
+package com.nainga.nainga.domain.tag.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Tag {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tag_id")
+    private Long id;
+    private String name;
+}


### PR DESCRIPTION
## ⭐️ Issue Number

- #10

## 🚩 Summary
가게별 인증제를 관리하기 위한 Tag Entity를 생성하고 이를 Store Entity와 연관 관계를 이어주기 위한 Join Entity로 StoreTag도 추가하였습니다.


## 🛠️ Technical Concerns

### Store과 Tag 사이 Entity model에 대한 고민

이 부분은 프로젝트 엔티티 모델 설계할 때 고민한 부분으로, Store와 Tag 사이의 관계를 Embeded key type을 활용하여 Join을 쓰지 않고 쿼리 성능을 높일지, 혹은 확장성을 고려하여 1:N N:1 관계로 N:M 관계를 풀어 구현할 지 등에 대한 고민을 많이 하였습니다.
결과적으로 저희는 Tag가 계속해서 추가될 수 있다는 요구사항이 있었기 때문에 확장성을 고려하여 1:N N:1 모델로 이 문제를 풀게되었고 성능 이슈같은 경우에는 추후에 캐싱 처리를 통해 해결할 계획입니다.

이 고민과 관련하여 자세한 내용 정리는 Wiki와 제 블로그에 정리되어있습니다.
- [블로그](https://sungjindev.github.io/posts/tagging-with-jpa/)
- [Wiki](https://github.com/Korea-Certified-Store/Docs/wiki/%5BBackend%5D-Tagging-%EA%B5%AC%ED%98%84%EC%9D%84-%EC%9C%84%ED%95%9C-Entity-%EC%84%A4%EA%B3%84)

### 양방향 연관 관계 vs 단방향 연관 관계

그렇게 Entity Model을 정한 뒤, 연관 관계를 맺어줄 때 단방향으로 맺을지 양방향으로 맺을지 고민하였습니다. 결과적으로 단방향 연관 관계로 설정하여도 Join 쿼리를 이용하여 원하는 모든 결과를 조회할 수 있고 오히려 양방향 연관 관계를 사용했을 때 객체 간의 연관 관계와 데이터베이스 테이블 간의 연관 관계의 싱크를 맞추기 위한 작업들이 수반되므로 굳이 필요하지 않다고 판단하였습니다. 그리고 무엇보다도 지금 설정한 Store Tag 사이의 연관 관계에서는 비즈니스 로직상 양방향 연관 관계 필요성을 크게 느끼지 못하여 모두 단방향 연관 관계로 설정하였습니다. 

## 📋 To Do

- 초기 가게 데이터들을 불러올 외부 API 연동 및 데이터 파싱 작업
- Store, Tag Entity를 사용한 API 개발

close #10 