### PR TITLE
GCS 설정

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -61,7 +61,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Test with Gradle
-        run: ./gradlew test
+        run: ./gradlew test -i
       # 또한, Github Actions 상에서는 머신의 IP 주소를 특정할 수가 없어서 도로명 주소 API 사용이 불가능하기 때문이 이와 관련된 테스트도 Skip!
       # 테스트 후 Result를 보기위해 Publish Unit Test Results step 추가
       - name: Publish Unit Test Results

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -61,7 +61,8 @@ jobs:
         run: chmod +x gradlew
 
       - name: Test with Gradle
-        run: ./gradlew test -i
+        run: ./gradlew test --full-stacktrace
+
       # 또한, Github Actions 상에서는 머신의 IP 주소를 특정할 수가 없어서 도로명 주소 API 사용이 불가능하기 때문이 이와 관련된 테스트도 Skip!
       # 테스트 후 Result를 보기위해 Publish Unit Test Results step 추가
       - name: Publish Unit Test Results

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
 	// 확장자를 읽어들이기 위해 추가
 	implementation group: 'commons-io', name: 'commons-io', version: '2.4'
 
+	// for GCS
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.8.RELEASE'
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage', version: '1.2.8.RELEASE'
+
 	// JsonParser를 사용하기 위해 추가
 	dependencies { implementation 'com.google.code.gson:gson:2.8.8' }
 

--- a/src/main/java/com/nainga/nainga/domain/gcsguide/GcsConfig.java
+++ b/src/main/java/com/nainga/nainga/domain/gcsguide/GcsConfig.java
@@ -1,0 +1,32 @@
+package com.nainga.nainga.domain.gcsguide;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ResourceUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class GcsConfig {
+
+    @Bean
+    public Storage storage() {
+        String keyFileName = "backend-submodule/kcs-dev-gcs.json";
+        Storage storage;
+        try {
+            InputStream keyFile = ResourceUtils.getURL("classpath:" + keyFileName).openStream();
+            storage = StorageOptions.newBuilder()
+                    .setCredentials(GoogleCredentials.fromStream(keyFile))
+                    .build()
+                    .getService();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("GCS 에러");
+        }
+
+        return storage;
+    }
+}

--- a/src/main/java/com/nainga/nainga/domain/gcsguide/GcsController.java
+++ b/src/main/java/com/nainga/nainga/domain/gcsguide/GcsController.java
@@ -1,0 +1,26 @@
+package com.nainga.nainga.domain.gcsguide;
+
+import com.nainga.nainga.global.util.Result;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class GcsController {
+
+    private final GcsService gcsService;
+
+    @Tag(name = "GCS")
+    @Operation(summary = "GCS 접속", description = "GCS 에 이미지 저장!")
+    @PostMapping(value = "api/v1/gcs",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Result<String> saveImageToGCS(@ModelAttribute GcsResponse response) {
+        String url = gcsService.uploadImage(response);
+        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, url);
+    }
+}

--- a/src/main/java/com/nainga/nainga/domain/gcsguide/GcsResponse.java
+++ b/src/main/java/com/nainga/nainga/domain/gcsguide/GcsResponse.java
@@ -1,0 +1,9 @@
+package com.nainga.nainga.domain.gcsguide;
+
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+public class GcsResponse {
+    private MultipartFile image;
+}

--- a/src/main/java/com/nainga/nainga/domain/gcsguide/GcsService.java
+++ b/src/main/java/com/nainga/nainga/domain/gcsguide/GcsService.java
@@ -5,7 +5,6 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,14 +16,12 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class GcsService {
 
-    @Value("${spring.cloud.gcp.storage.bucket}") // application.yml에 써둔 bucket 이름
-    private String bucketName;
-
     private final Storage storage;
 
     public String uploadImage(GcsResponse response) {
 
         // 이미지 업로드
+        String bucketName = "kcs-dev-bucket";
         String uuid = UUID.randomUUID().toString(); // Google Cloud Storage에 저장될 파일 이름(중복 이름 안되게 저장하도록 주의)
         String ext = response.getImage().getContentType(); // 파일의 형식 ex) JPG
 

--- a/src/main/java/com/nainga/nainga/domain/gcsguide/GcsService.java
+++ b/src/main/java/com/nainga/nainga/domain/gcsguide/GcsService.java
@@ -1,0 +1,46 @@
+package com.nainga.nainga.domain.gcsguide;
+
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GcsService {
+
+    @Value("${spring.cloud.gcp.storage.bucket}") // application.yml에 써둔 bucket 이름
+    private String bucketName;
+
+    private final Storage storage;
+
+    public String uploadImage(GcsResponse response) {
+
+        // 이미지 업로드
+        String uuid = UUID.randomUUID().toString(); // Google Cloud Storage에 저장될 파일 이름(중복 이름 안되게 저장하도록 주의)
+        String ext = response.getImage().getContentType(); // 파일의 형식 ex) JPG
+
+        // Cloud에 이미지 업로드
+        // 이미지 접근 url : https://storage.googleapis.com/버킷이름/UUID값
+        try {
+            BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, uuid)
+                    .setContentType(ext)
+                    .build();
+
+            // Cloud 에 업로드
+            Blob blob = storage.create(blobInfo, response.getImage().getBytes());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("GCS 에러");
+        }
+
+        return "https://storage.googleapis.com/" + bucketName + "/" + uuid;
+    }
+}


### PR DESCRIPTION
## ⭐️ Issue Number

- #40 

## 🚩 Summary

GCS 를 이용하여 이미지를 저장합니다. SpringBoot 에서 GCS 활용하는 가이드라인 예제를 만들어두었습니다.


## 🛠️ Technical Concerns

### GCS VS AWS S3

AWS S3 프리티어와 GCS(Google Cloud Storage) 를 비교해본 결과 S3 프리티어의 경우 insert 요청이 2000건으로 제한되어있습니다. 저희 프로젝트의 경우 초기 insert 요청이 최소 5만건이 넘기때문에 프리티어로 사용하는데는 한계가 있습니다. GCS 의 경우 무료크레딧을 제공하기때문에 이를 활용하여 사용하는게 좋다고 판단했습니다.

### 파일이름 중복 주의

가이드라인에서는 파일명을 UUID 로 제공했습니다. 최대한 파일이름 중복되지 않기위해서입니다. 파일명이 중복되면 덮어쓰기가 되므로 주의를 요구합니다.

### 서브모듈 사용으로 인한 문제

GCS 접근을 위한 키를 서브모듈 안에 저장해두었습니다. 그랬더니 Default 설정으로 해당 키파일을 찾지 못하는 문제가 발생했습니다. 이는 직접 GcsConfig 파일을 통해 파일위치를 명시하여 해결하였습니다.

close #40 
