### PR TITLE
운영 서버 CD

### DIFF
--- a/.github/workflows/action-production-cd.yml
+++ b/.github/workflows/action-production-cd.yml
@@ -1,0 +1,90 @@
+name: action-production-cd
+
+# 언제 이 파일의 내용이 실행될 것인지 정의
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - develop
+      - feature/**
+
+# 코드의 내용을 이 파일을 실행하여 action을 수행하는 주체(Github Actions에서 사용하는 VM)가 읽을 수 있도록 권한을 설정
+permissions:
+  contents: read
+
+# 실제 실행될 내용들을 정의합니다.
+jobs:
+  build:
+    runs-on: ubuntu-latest # ubuntu 최신 버전에서 script를 실행
+    steps:
+      # 지정한 저장소(현재 REPO)에서 코드를 워크플로우 환경으로 가져오도록 하는 github action
+      # submodule 을 사용하기 위한 설정을 추가
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          token: ${{secrets.ACTION_TOKEN}}
+          submodules: true
+
+      # open jdk 17 버전 환경을 세팅
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: "corretto"
+
+      # 캐시를 사용하기위해 buildx 를 사용
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      # gradle을 통해 소스를 빌드.
+      - name: Build with gradle
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build -x test
+
+      # 도커 컴포즈 설정 파일 서버로 전달
+      - name: Send docker-compose.yml
+        uses: appleboy/scp-action@master
+        with:
+          username: ${{ secrets.KCS_USERNAME_PROD }}
+          host: ${{ secrets.KCS_HOST_PROD }}
+          key: ${{ secrets.KCS_KEY_PROD }}
+          source: "src/main/resources/backend-submodule/docker-compose-dev.yml"
+          target: "/home/ubuntu/"
+
+      # Docker hub 로그인
+      - name: Login to dockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME}}
+          password: ${{ secrets.DOCKER_TOKEN}}
+
+      # Docker Hub 에 푸시
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile.dev
+          push: true
+          tags: ${{ secrets.DOCKER_REPOSITORY }}:latest
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
+      # appleboy/ssh-action@master 액션을 사용하여 지정한 서버에 ssh로 접속하고, script를 실행합니다.
+      # 실행 시, docker-compose를 사용합니다.
+      - name: Deploy to server
+        uses: appleboy/ssh-action@master
+        with:
+          username: ${{ secrets.KCS_USERNAME_PROD }}
+          host: ${{ secrets.KCS_HOST_PROD }}
+          key: ${{ secrets.KCS_KEY_PROD }}
+          script: |
+            docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+            sudo docker pull {{ secrets.DOCKER_REPOSITORY }}:latest
+            docker-compose -f docker-compose-dev.yml down
+            docker rmi $(docker images -q)
+            cp -f ./src/main/resources/backend-submodule/docker-compose-dev.yml .
+            rm -r src
+            docker-compose -f docker-compose-dev.yml up -d


### PR DESCRIPTION
## ⭐️ Issue Number

- #46 

## 🚩 Summary

main 브랜치에 푸시가 되면 운영 서버에 자동으로 배포를 해줍니다.
GCP, Cloud SQL, GCS 를 사용했습니다.

## 🛠️ Technical Concerns

### GCP

무료크레딧을 사용할 수 있는 GCP 를 사용합니다. 개발 서버인 EC2 프리티어보다 더욱더 고성능으로 사용할 수 있습니다. 대신 크레딧이 끝나면 새로운 계정으로 마이그레이션이 필요합니다.

