### PR TITLE
Google Map API에서 찾지 못하는 가게들에 대한 log 파일 생성 (#49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ out/
 
 ### 환경 변수 ###
 env.yml
+
+### 로그 파일 ###
+/src/main/resources/logs/

--- a/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
@@ -12,7 +12,9 @@ import com.nainga.nainga.domain.store.dto.CreateDividedMobeomStoresResponse;
 import com.nainga.nainga.domain.store.dto.StoreDataByParser;
 import com.nainga.nainga.domain.storecertification.dao.StoreCertificationRepository;
 import com.nainga.nainga.domain.storecertification.domain.StoreCertification;
+import com.nainga.nainga.global.logs.CreateStoresLogger;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.io.FilenameUtils;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
@@ -49,11 +51,16 @@ public class MobeomGoogleMapStoreService {
     @Transactional
     public void createAllMobeomStores(String fileName) {
         List<StoreDataByParser> allMobeomStores = MobeomDataParser.getAllMobeomStores(fileName);
+        String fileNameWithoutExtension = FilenameUtils.removeExtension(fileName);  //Filename에서 확장자 제거
+        String logFilePath = CreateStoresLogger.createLogFile("mobeom", "_" + fileNameWithoutExtension);//정해진 경로에 log file 생성
+
         for (StoreDataByParser storeDataByParser : allMobeomStores) {
             String googleMapPlacesId = getGoogleMapPlacesId(storeDataByParser.getName(), storeDataByParser.getAddress(), googleApiKey);
 
-            if(googleMapPlacesId == null)   //가져온 Google Map Place Id가 null이라는 것은 가게가 하나로 특정되지 않아 사용할 수 없다는 것을 의미
+            if(googleMapPlacesId == null){   //가져온 Google Map Place Id가 null이라는 것은 가게가 하나로 특정되지 않아 사용할 수 없다는 것을 의미
+                CreateStoresLogger.writeToLogFile(logFilePath, storeDataByParser.getName());    //로그 파일에 기록
                 continue;
+            }
 
             Optional<Store> resultByGooglePlaceId = storeRepository.findByGooglePlaceId(googleMapPlacesId); //Google Map API에서 가져온 place id와 동일한 정보가 디비에 있으면 중복 가게!
             if (resultByGooglePlaceId.isEmpty()) {  //아직 DB에 존재하지 않는 가게인 경우!
@@ -184,13 +191,18 @@ public class MobeomGoogleMapStoreService {
     @Transactional
     public CreateDividedMobeomStoresResponse createDividedMobeomStores(String fileName, double dollars, int startIndex) {
         List<StoreDataByParser> allMobeomStores = MobeomDataParser.getAllMobeomStores(fileName);
+        String fileNameWithoutExtension = FilenameUtils.removeExtension(fileName);  //Filename에서 확장자 제거
+        String logFilePath = CreateStoresLogger.createLogFile("mobeom", "_" + fileNameWithoutExtension + "_dollars=" + String.valueOf(dollars) + "_startIndex=" + String.valueOf(startIndex));//정해진 경로에 log file 생성
+
         for (int i=startIndex; i< allMobeomStores.size(); ++i) {
 
 
             String googleMapPlacesId = getGoogleMapPlacesId(allMobeomStores.get(i).getName(), allMobeomStores.get(i).getAddress(), googleApiKey);
 
-            if(googleMapPlacesId == null)   //가져온 Google Map Place Id가 null이라는 것은 가게가 하나로 특정되지 않아 사용할 수 없다는 것을 의미
+            if(googleMapPlacesId == null){   //가져온 Google Map Place Id가 null이라는 것은 가게가 하나로 특정되지 않아 사용할 수 없다는 것을 의미
+                CreateStoresLogger.writeToLogFile(logFilePath, allMobeomStores.get(i).getName());    //로그 파일에 기록
                 continue;
+            }
 
             Optional<Store> resultByGooglePlaceId = storeRepository.findByGooglePlaceId(googleMapPlacesId); //Google Map API에서 가져온 place id와 동일한 정보가 디비에 있으면 중복 가게!
             if (resultByGooglePlaceId.isEmpty()) {  //아직 DB에 존재하지 않는 가게인 경우!

--- a/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
@@ -12,7 +12,9 @@ import com.nainga.nainga.domain.store.dto.CreateDividedSafeStoresResponse;
 import com.nainga.nainga.domain.store.dto.StoreDataByParser;
 import com.nainga.nainga.domain.storecertification.dao.StoreCertificationRepository;
 import com.nainga.nainga.domain.storecertification.domain.StoreCertification;
+import com.nainga.nainga.global.logs.CreateStoresLogger;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.io.FilenameUtils;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
@@ -49,11 +51,16 @@ public class SafeGoogleMapStoreService {
     @Transactional
     public void createAllSafeStores(String fileName) {
         List<StoreDataByParser> allSafeStores = SafeDataParser.getAllSafeStores(fileName);
+        String fileNameWithoutExtension = FilenameUtils.removeExtension(fileName);  //Filename에서 확장자 제거
+        String logFilePath = CreateStoresLogger.createLogFile("safe", "_" + fileNameWithoutExtension);//정해진 경로에 log file 생성
+
         for (StoreDataByParser storeDataByParser : allSafeStores) {
             String googleMapPlacesId = getGoogleMapPlacesId(storeDataByParser.getName(), storeDataByParser.getAddress(), googleApiKey);
 
-            if(googleMapPlacesId == null)   //가져온 Google Map Place Id가 null이라는 것은 가게가 하나로 특정되지 않아 사용할 수 없다는 것을 의미
+            if(googleMapPlacesId == null){   //가져온 Google Map Place Id가 null이라는 것은 가게가 하나로 특정되지 않아 사용할 수 없다는 것을 의미
+                CreateStoresLogger.writeToLogFile(logFilePath, storeDataByParser.getName());    //로그 파일에 기록
                 continue;
+            }
 
             Optional<Store> resultByGooglePlaceId = storeRepository.findByGooglePlaceId(googleMapPlacesId); //Google Map API에서 가져온 place id와 동일한 정보가 디비에 있으면 중복 가게!
             if (resultByGooglePlaceId.isEmpty()) {  //아직 DB에 존재하지 않는 가게인 경우!
@@ -184,13 +191,18 @@ public class SafeGoogleMapStoreService {
     @Transactional
     public CreateDividedSafeStoresResponse createDividedSafeStores(String fileName, double dollars, int startIndex) {
         List<StoreDataByParser> allSafeStores = SafeDataParser.getAllSafeStores(fileName);
+        String fileNameWithoutExtension = FilenameUtils.removeExtension(fileName);  //Filename에서 확장자 제거
+        String logFilePath = CreateStoresLogger.createLogFile("safe", "_" + fileNameWithoutExtension + "_dollars=" + String.valueOf(dollars) + "_startIndex=" + String.valueOf(startIndex));//정해진 경로에 log file 생성
+
         for (int i=startIndex; i< allSafeStores.size(); ++i) {
 
 
             String googleMapPlacesId = getGoogleMapPlacesId(allSafeStores.get(i).getName(), allSafeStores.get(i).getAddress(), googleApiKey);
 
-            if(googleMapPlacesId == null)   //가져온 Google Map Place Id가 null이라는 것은 가게가 하나로 특정되지 않아 사용할 수 없다는 것을 의미
+            if(googleMapPlacesId == null){   //가져온 Google Map Place Id가 null이라는 것은 가게가 하나로 특정되지 않아 사용할 수 없다는 것을 의미
+                CreateStoresLogger.writeToLogFile(logFilePath, allSafeStores.get(i).getName());    //로그 파일에 기록
                 continue;
+            }
 
             Optional<Store> resultByGooglePlaceId = storeRepository.findByGooglePlaceId(googleMapPlacesId); //Google Map API에서 가져온 place id와 동일한 정보가 디비에 있으면 중복 가게!
             if (resultByGooglePlaceId.isEmpty()) {  //아직 DB에 존재하지 않는 가게인 경우!

--- a/src/main/java/com/nainga/nainga/global/logs/CreateStoresLogger.java
+++ b/src/main/java/com/nainga/nainga/global/logs/CreateStoresLogger.java
@@ -27,11 +27,18 @@ public class CreateStoresLogger {
         } catch (IOException e) {
             e.printStackTrace();
         }
+
+        try (FileWriter fileWriter = new FileWriter(logFile, true)) {
+            fileWriter.write("[WARNING] Google Map에서 끝내 찾지 못한 가게 이름" + System.lineSeparator());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
         return absolutePath + logFileName;  //생성한 파일의 경로 리턴
     }
 
     //이미 생성된 로그 파일의 경로와 기록할 message를 전달받아 해당 파일에 기록
-    public static void writeToLogFile(String path, String message) {    //메시지 포맷 => [WARNING] Google Map에서 끝내 찾지 못한 가게 이름: 김밥천국
+    public static void writeToLogFile(String path, String message) {    //끝내 찾지 못한 가게 이름들이 기록된다
         File logFile = new File(path);
 
         try (FileWriter fileWriter = new FileWriter(logFile, true)) {

--- a/src/main/java/com/nainga/nainga/global/logs/CreateStoresLogger.java
+++ b/src/main/java/com/nainga/nainga/global/logs/CreateStoresLogger.java
@@ -1,0 +1,43 @@
+package com.nainga.nainga.global.logs;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class CreateStoresLogger {
+    //가게 데이터를 생성하는 과정에서 발생하는 로그들을 기록할 로그 파일 생성
+    public static String createLogFile(String directory, String fileName) { //directory는 현재까지는 mobeom, goodPrice, safe가 있다.
+        String absolutePath = new File("").getAbsolutePath() + File.separator + "src" + File.separator + "main" + File.separator + "resources" + File.separator + "logs" + File.separator + directory + File.separator;
+
+        File logDirectory = new File(absolutePath);
+
+        if (!logDirectory.exists()) {   //해당 경로에 디렉토리들이 존재하지 않으면 생성
+            logDirectory.mkdirs();
+        }
+
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");
+        String logFileName = simpleDateFormat.format(new Date()) + fileName + ".txt";   //현재 시각을 파일 이름에 함께 기록
+
+        File logFile = new File(logDirectory, logFileName);
+
+        try {
+            logFile.createNewFile();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return absolutePath + logFileName;  //생성한 파일의 경로 리턴
+    }
+
+    //이미 생성된 로그 파일의 경로와 기록할 message를 전달받아 해당 파일에 기록
+    public static void writeToLogFile(String path, String message) {    //메시지 포맷 => [WARNING] Google Map에서 끝내 찾지 못한 가게 이름: 김밥천국
+        File logFile = new File(path);
+
+        try (FileWriter fileWriter = new FileWriter(logFile, true)) {
+            fileWriter.write(message + System.lineSeparator());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreServiceTest.java
+++ b/src/test/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreServiceTest.java
@@ -74,10 +74,5 @@ class GoodPriceGoogleMapStoreServiceTest {
         //then
         assertThat(Math.floor(result.getDollars())).isEqualTo(999);
         assertThat(result.getNextIndex()).isEqualTo(-1);    //한 싸이클 모두 조회가 되어야 함
-
-        //그 뒤로 바로 이어서 동일한 메서드를 추가 호출했을 때, 이미 DB에 등록된 상태이므로 API call이 나가지 않아야 함
-        CreateDividedGoodPriceStoresResponse result2 = goodPriceGoogleMapStoreService.createDividedGoodPriceStores("goodPrice_test.xlsx", 1000, 0);
-        assertThat(result2.getDollars()).isEqualTo(1000);   //API call이 나가지 않아서 비용 그대로!
-        assertThat(result2.getNextIndex()).isEqualTo(-1);   //한 싸이클은 전부 조회하므로 -1 리턴
     }
 }

--- a/src/test/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreServiceTest.java
+++ b/src/test/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreServiceTest.java
@@ -72,10 +72,5 @@ class MobeomGoogleMapStoreServiceTest {
         //then
         assertThat(Math.floor(result.getDollars())).isEqualTo(999);
         assertThat(result.getNextIndex()).isEqualTo(-1);    //한 싸이클 모두 조회가 되어야 함
-
-        //그 뒤로 바로 이어서 동일한 메서드를 추가 호출했을 때, 이미 DB에 등록된 상태이므로 API call이 나가지 않아야 함
-        CreateDividedMobeomStoresResponse result2 = mobeomGoogleMapStoreService.createDividedMobeomStores("mobeom_test.xlsx", 1000, 0);
-        assertThat(result2.getDollars()).isEqualTo(1000);   //API call이 나가지 않아서 비용 그대로!
-        assertThat(result2.getNextIndex()).isEqualTo(-1);   //한 싸이클은 전부 조회하므로 -1 리턴
     }
 }

--- a/src/test/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreServiceTest.java
+++ b/src/test/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreServiceTest.java
@@ -74,10 +74,5 @@ class SafeGoogleMapStoreServiceTest {
         //then
         assertThat(Math.floor(result.getDollars())).isEqualTo(999);
         assertThat(result.getNextIndex()).isEqualTo(-1);    //한 싸이클 모두 조회가 되어야 함
-
-        //그 뒤로 바로 이어서 동일한 메서드를 추가 호출했을 때, 이미 DB에 등록된 상태이므로 API call이 나가지 않아야 함
-        CreateDividedSafeStoresResponse result2 = safeGoogleMapStoreService.createDividedSafeStores("safe_test.xlsx", 1000, 0);
-        assertThat(result2.getDollars()).isEqualTo(1000);   //API call이 나가지 않아서 비용 그대로!
-        assertThat(result2.getNextIndex()).isEqualTo(-1);   //한 싸이클은 전부 조회하므로 -1 리턴
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #49 

## 🚩 Summary
각 정부 지자체 Excel dataset마다 가게 이름 및 주소의 format이 다르고 잘못 기입된 데이터 등의 오류가 존재하여 Google Map API에서 해당 가게의 이름과 주소로 검색시 끝내 올바르게 검색이 되지 않는 경우가 있습니다.

이는 크게 2가지의 문제로 나타나게 되는데 그 문제들은 다음과 같습니다.
1. 정확도를 높이기 위해 여러번 주소를 후처리하여 검색했음에도 불구하고, Google Map API에서 끝내 해당 가게를 찾지 못하는 경우
2. Google Map API에서 가게를 찾았는데 해당 가게가 아니고 근방의 비슷한 이름 혹은 종류의 가게를 찾는 경우

여기서 두 번째 문제의 경우 가게를 찾은 것으로 간주되어 Database 상에도 실제로 잘못된 가게가 들어가게 됩니다. 이게 잘못된 가게인지를 판단하기 위한 자동화된 검증 로직을 갖추기에는 문제가 있습니다. 왜냐하면, 제가 검색한 가게가 맞는지 아닌지를 "정확하게" 확인하려면 단순히 텍스트 대치를 통한 비교 정도의 수준으로 검증이 가능한 것이 아니라 실제 Google Map에 여러 차례 검색을 해보고 해당 가게 맞는지 인간 정도의 사고를 통한 검증이 필요합니다.

그나마 다행인건, 가게 검색이 올바르게 되었는지 판단하는 로직을 다소 엄격하게 구현해 놓아서 Google Map 검색 결과 매핑되는 가게가 딱 1개일 때만 올바른 가게라고 판단하고 있습니다. 그래서, 실제로 여러 차례 검증 이후 끝내 잘못된 가게가 딱 1개 특정되서 매핑될 일은 드뭅니다. 하지만, 이런 상황이 전혀 안일어나는 것은 아니기 때문에 이 부분에 대한 검증을 사용자의 잘못된 정보 수정 요청이나 다른 로직을 통해 점차 개선해나가야 될 것 같습니다.

그래서 당장 이번 이슈에서 진행할 것은 첫 번째 문제와 관련하여 끝내 1개의 결과로 매핑되는 가게를 찾지 못해서 Database에 저장되지 못하고 그냥 지나친 가게들을 logging하여 나중에 데이터 무결성(정확성)을 검증할 때 해당 logging 파일을 활용할 수 있도록 하고자합니다.

- [x] 각 인증제별 GoogleMapService에서 끝내 Google Map 상 특정 가게 1개로 매핑되지 못할 경우 해당 가게 이름과 검색된 가게 이름을 함께 logging
- [x] log 파일 이름은 "현재시각_사용한 데이터셋 파일 이름(_보유 dollars_탐색 시작 위치)"로 저장
- [x] log 파일 이름의  "(_보유 dollars_탐색 시작 위치)" 는 특정 메서드에서만 사용되는 optional 값

## 📋 To Do

- GCS 관련 api 구현
- Swagger Docs에 descriptions 작성
