### PR TITLE
이미지 저장 로직에 GCS 적용 (#54)

### DIFF
--- a/src/main/java/com/nainga/nainga/NaingaApplication.java
+++ b/src/main/java/com/nainga/nainga/NaingaApplication.java
@@ -1,6 +1,5 @@
 package com.nainga.nainga;
 
-import com.nainga.nainga.domain.store.application.GoogleMapMethods;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 

--- a/src/main/java/com/nainga/nainga/domain/gcsguide/GcsController.java
+++ b/src/main/java/com/nainga/nainga/domain/gcsguide/GcsController.java
@@ -1,29 +1,29 @@
-package com.nainga.nainga.domain.gcsguide;
-
-import com.nainga.nainga.global.util.Result;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Profile;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@Profile({"dev", "prod"})
-@RestController
-@RequiredArgsConstructor
-public class GcsController {
-
-
-    private final GcsService gcsService;
-
-    @Tag(name = "GCS")
-    @Operation(summary = "GCS 접속", description = "GCS 에 이미지 저장!")
-    @PostMapping(value = "api/v1/gcs",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public Result<String> saveImageToGCS(@ModelAttribute GcsResponse response) {
-        String url = gcsService.uploadImage(response);
-        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, url);
-    }
-}
+//package com.nainga.nainga.domain.gcsguide;
+//
+//import com.nainga.nainga.global.util.Result;
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.context.annotation.Profile;
+//import org.springframework.http.MediaType;
+//import org.springframework.web.bind.annotation.ModelAttribute;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//@Profile({"dev", "prod"})
+//@RestController
+//@RequiredArgsConstructor
+//public class GcsController {
+//
+//
+//    private final GcsService gcsService;
+//
+//    @Tag(name = "GCS")
+//    @Operation(summary = "GCS 접속", description = "GCS 에 이미지 저장!")
+//    @PostMapping(value = "api/v1/gcs",
+//            consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+//    public Result<String> saveImageToGCS(@ModelAttribute GcsResponse response) {
+//        String url = gcsService.uploadImage(response);
+//        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, url);
+//    }
+//}

--- a/src/main/java/com/nainga/nainga/domain/gcsguide/GcsService.java
+++ b/src/main/java/com/nainga/nainga/domain/gcsguide/GcsService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.UUID;
 
 @Profile({"dev", "prod"})
@@ -24,24 +25,20 @@ public class GcsService {
     @Value("${GOOGLE_GCS_BUCKET}")
     private String bucketName;
 
-    public String uploadImage(GcsResponse response) {
+    @Transactional
+    public String uploadImage(byte[] bytes) {
 
         // 이미지 업로드
         String uuid = UUID.randomUUID().toString(); // Google Cloud Storage에 저장될 파일 이름(중복 이름 안되게 저장하도록 주의)
-        String ext = response.getImage().getContentType(); // 파일의 형식 ex) JPG
+        String ext = ".jpg"; // 파일의 형식 ex) JPG
 
         // Cloud에 이미지 업로드
         // 이미지 접근 url : https://storage.googleapis.com/버킷이름/UUID값
-        try {
-            BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, uuid)
-                    .setContentType(ext)
-                    .build();
-
-            // Cloud 에 업로드
-            Blob blob = storage.create(blobInfo, response.getImage().getBytes());
-        } catch (IOException e) {
-            throw new IllegalArgumentException("GCS 에러");
-        }
+        BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, uuid)
+                .setContentType(ext)
+                .build();
+        // Cloud 에 업로드
+        Blob blob = storage.create(blobInfo, bytes);
 
         return "https://storage.googleapis.com/" + bucketName + "/" + uuid;
     }

--- a/src/main/java/com/nainga/nainga/domain/store/api/StoreApi.java
+++ b/src/main/java/com/nainga/nainga/domain/store/api/StoreApi.java
@@ -22,7 +22,6 @@ public class StoreApi {
     private final SafeGoogleMapStoreService safeGoogleMapStoreService;
     private final GoodPriceGoogleMapStoreService goodPriceGoogleMapStoreService;
 
-    @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "모범음식점 데이터 생성", description = "[WARNING] DB에 처음으로 모든 모범음식점 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
     @GetMapping("api/v1/store/mobeom")
@@ -31,7 +30,6 @@ public class StoreApi {
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, null);
     }
 
-    @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "지정한 Credit까지만 사용하여 모범음식점 데이터 생성", description = "[WARNING] 지정한 Credit까지만 사용하여 그동안 DB에 모범음식점 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
     @GetMapping("api/v1/store/dividedMobeom")
@@ -41,7 +39,6 @@ public class StoreApi {
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, response);
     }
 
-    @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "안심식당 데이터 생성", description = "[WARNING] DB에 처음으로 모든 안심식당 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
     @GetMapping("api/v1/store/safe")
@@ -50,7 +47,6 @@ public class StoreApi {
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, null);
     }
 
-    @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "지정한 Credit까지만 사용하여 안심식당 데이터 생성", description = "[WARNING] 지정한 Credit까지만 사용하여 그동안 DB에 안심식당 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
     @GetMapping("api/v1/store/dividedSafe")
@@ -60,7 +56,6 @@ public class StoreApi {
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, response);
     }
 
-    @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "착한가격업소 데이터 생성", description = "[WARNING] DB에 처음으로 모든 착한가격업소 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
     @GetMapping("api/v1/store/goodPrice")
@@ -69,7 +64,6 @@ public class StoreApi {
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, null);
     }
 
-    @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "지정한 Credit까지만 사용하여 착한가격업소 데이터 생성", description = "[WARNING] 지정한 Credit까지만 사용하여 그동안 DB에 착한가격업소 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
     @GetMapping("api/v1/store/dividedGoodPrice")

--- a/src/main/java/com/nainga/nainga/domain/store/api/StoreApi.java
+++ b/src/main/java/com/nainga/nainga/domain/store/api/StoreApi.java
@@ -11,7 +11,9 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
@@ -276,11 +276,30 @@ public class GoodPriceGoogleMapStoreService {
                             return createDividedGoodPriceStoresResponse;
                         }
                         //돈이 충분히 있으면,
-                        localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                        googlePhotosList.remove(0);
-
-                        //소비한 비용 반영
-                        dollars -= 0.007;
+                        if (currentProfile.equals("dev")) {
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            if (googleMapPlacesImageAsBytes != null) {
+                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
+                                localPhotosList.add(gcsPath);
+                                googlePhotosList.remove(0);
+                                //소비한 비용 반영
+                                dollars -= 0.007;
+                            }
+                        } else if (currentProfile.equals("prod")) {
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            if (googleMapPlacesImageAsBytes != null) {
+                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
+                                localPhotosList.add(gcsPath);
+                                googlePhotosList.remove(0);
+                                //소비한 비용 반영
+                                dollars -= 0.007;
+                            }
+                        } else {    //local이나 test 시
+                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
+                            googlePhotosList.remove(0);
+                            //소비한 비용 반영
+                            dollars -= 0.007;
+                        }
                     }
 
                     //얻어온 가게 상세 정보를 바탕으로 DB에 저장할 객체를 생성

--- a/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
@@ -112,14 +112,7 @@ public class GoodPriceGoogleMapStoreService {
                         continue;
 
                     if (!googlePhotosList.isEmpty()) {  //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                        if (currentProfile.equals("dev")) {
-                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
-                            if (googleMapPlacesImageAsBytes != null) {
-                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
-                                localPhotosList.add(gcsPath);
-                                googlePhotosList.remove(0);
-                            }
-                        } else if (currentProfile.equals("prod")) {
+                        if (currentProfile.equals("dev") || currentProfile.equals("prod")) {
                             byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
                             if (googleMapPlacesImageAsBytes != null) {
                                 String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
@@ -287,16 +280,7 @@ public class GoodPriceGoogleMapStoreService {
                             return createDividedGoodPriceStoresResponse;
                         }
                         //돈이 충분히 있으면,
-                        if (currentProfile.equals("dev")) {
-                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
-                            if (googleMapPlacesImageAsBytes != null) {
-                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
-                                localPhotosList.add(gcsPath);
-                                googlePhotosList.remove(0);
-                                //소비한 비용 반영
-                                dollars -= 0.007;
-                            }
-                        } else if (currentProfile.equals("prod")) {
+                        if (currentProfile.equals("dev") || currentProfile.equals("prod")) {
                             byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
                             if (googleMapPlacesImageAsBytes != null) {
                                 String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);

--- a/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +42,17 @@ public class GoodPriceGoogleMapStoreService {
     private final CertificationRepository certificationRepository;
     private final StoreCertificationRepository storeCertificationRepository;
     private final GcsService gcsService;
+
+    //아래 생성자 주입을 별도로 작성한 이유는 특정 Profile에서만 의존성 주입이 필요한 GcsService에 @Autowired(required = false)를 적용해주기 위해
+    @Autowired
+    public GoodPriceGoogleMapStoreService(@Value("${GOOGLE_API_KEY}") String googleApiKey,@Value("${CURRENT_PROFILE}") String currentProfile, StoreRepository storeRepository, CertificationRepository certificationRepository, StoreCertificationRepository storeCertificationRepository, @Autowired(required = false) GcsService gcsService) {
+        this.googleApiKey = googleApiKey;
+        this.currentProfile = currentProfile;
+        this.storeRepository = storeRepository;
+        this.certificationRepository = certificationRepository;
+        this.storeCertificationRepository = storeCertificationRepository;
+        this.gcsService = gcsService;
+    }
 
     //이 메서드는 GoodPrice Excel dataset 파싱을 통해 가게 이름과 주소를 얻고, 이 정보를 바탕으로 Google Map Place Id를 가져옵니다.
     //그 후 얻어진 Google Map Place Id를 가지고 가게 상세 정보를 Google Map API로부터 가져와 Store DB에 저장합니다.

--- a/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
@@ -1,6 +1,6 @@
 package com.nainga.nainga.domain.store.application;
 
-import com.google.gson.*;
+import com.google.gson.JsonObject;
 import com.nainga.nainga.domain.certification.dao.CertificationRepository;
 import com.nainga.nainga.domain.certification.domain.Certification;
 import com.nainga.nainga.domain.store.dao.StoreRepository;
@@ -22,17 +22,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import static com.nainga.nainga.domain.store.application.GoogleMapMethods.*;
 

--- a/src/main/java/com/nainga/nainga/domain/store/application/GoogleMapMethods.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/GoogleMapMethods.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.UUID;
 
 public class GoogleMapMethods {
-    //아래 메서드는 Google Map API 내 사진 요청 API를 트리거하여 API call
-    public static String getGoogleMapPlacesImage(String photosName, String googleApiKey) {
+    //아래 메서드는 Google Map API 내 사진 요청 API를 통해 이미지 한장을 가져와서 Local에 저장
+    public static String getGoogleMapPlacesImageToLocal(String photosName, String googleApiKey) {
         String maxWidthPx = "400";
         String maxHeightPx = "400";
 
@@ -43,6 +43,31 @@ public class GoogleMapMethods {
         }
 
         return localFilePath;
+    }
+
+    //아래 메서드는 Google Map API를 통해 해당 name에 해당하는 이미지의 Bytes를 가져와 반환
+    //이렇게 가져오는 이유는 GCS에 저장하기 위해
+    public static byte[] getGoogleMapPlacesImageAsBytes(String photosName, String googleApiKey) {
+        String maxWidthPx = "400";
+        String maxHeightPx = "400";
+
+        String reqURL = "https://places.googleapis.com/v1/" + photosName + "/media?maxHeightPx=" + maxHeightPx + "&maxWidthPx=" + maxWidthPx + "&key=" + googleApiKey;
+
+        try {
+            URL url = new URL(reqURL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            InputStream inputStream = conn.getInputStream();
+            byte[] bytes = inputStream.readAllBytes();
+            inputStream.close();
+            conn.disconnect();
+
+            return bytes;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return null;    //제대로 가져오지 못하면 null 반환
     }
 
     //이 메서드는 Google Map API 내 "텍스트 검색(신규)"를 활용하여 텍스트 기반으로 검색하고 매칭되는 가게의 places.id를 가져옵니다.

--- a/src/main/java/com/nainga/nainga/domain/store/application/MobeomDataParser.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/MobeomDataParser.java
@@ -11,7 +11,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /*
 모범 음식점 관련 데이터들을 파싱하기 위한 클래스

--- a/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
@@ -96,7 +96,7 @@ public class MobeomGoogleMapStoreService {
                         continue;
 
                     if (!googlePhotosList.isEmpty()) {  //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                        localPhotosList.add(getGoogleMapPlacesImage(googlePhotosList.get(0), googleApiKey));
+                        localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey));
                         googlePhotosList.remove(0);
                     }
 
@@ -255,7 +255,7 @@ public class MobeomGoogleMapStoreService {
                             return createDividedMobeomStoresResponse;
                         }
                         //돈이 충분히 있으면,
-                        localPhotosList.add(getGoogleMapPlacesImage(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
+                        localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
                         googlePhotosList.remove(0);
 
                         //소비한 비용 반영

--- a/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
@@ -113,14 +113,7 @@ public class MobeomGoogleMapStoreService {
                         continue;
 
                     if (!googlePhotosList.isEmpty()) {  //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                        if (currentProfile.equals("dev")) {
-                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
-                            if (googleMapPlacesImageAsBytes != null) {
-                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
-                                localPhotosList.add(gcsPath);
-                                googlePhotosList.remove(0);
-                            }
-                        } else if (currentProfile.equals("prod")) {
+                        if (currentProfile.equals("dev") || currentProfile.equals("prod")) {
                             byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
                             if (googleMapPlacesImageAsBytes != null) {
                                 String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
@@ -288,16 +281,7 @@ public class MobeomGoogleMapStoreService {
                             return createDividedMobeomStoresResponse;
                         }
                         //돈이 충분히 있으면,
-                        if (currentProfile.equals("dev")) {
-                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
-                            if (googleMapPlacesImageAsBytes != null) {
-                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
-                                localPhotosList.add(gcsPath);
-                                googlePhotosList.remove(0);
-                                //소비한 비용 반영
-                                dollars -= 0.007;
-                            }
-                        } else if (currentProfile.equals("prod")) {
+                        if (currentProfile.equals("dev") || currentProfile.equals("prod")) {
                             byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
                             if (googleMapPlacesImageAsBytes != null) {
                                 String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);

--- a/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
@@ -3,6 +3,7 @@ package com.nainga.nainga.domain.store.application;
 import com.google.gson.JsonObject;
 import com.nainga.nainga.domain.certification.dao.CertificationRepository;
 import com.nainga.nainga.domain.certification.domain.Certification;
+import com.nainga.nainga.domain.gcsguide.GcsService;
 import com.nainga.nainga.domain.store.dao.StoreRepository;
 import com.nainga.nainga.domain.store.domain.Store;
 import com.nainga.nainga.domain.store.domain.StoreDay;
@@ -34,9 +35,13 @@ import static com.nainga.nainga.domain.store.application.GoogleMapMethods.*;
 public class MobeomGoogleMapStoreService {
     @Value("${GOOGLE_API_KEY}")
     private String googleApiKey;    //Spring bean 내에서만 @Value로 프로퍼티를 가져올 수 있어서 Service 단에서 받고 GoogleMapMethods에는 파라미터로 넘겨줌.
+    @Value("${CURRENT_PROFILE}")
+    private String currentProfile;  //현재 Active Profile을 조회
     private final StoreRepository storeRepository;
     private final CertificationRepository certificationRepository;
     private final StoreCertificationRepository storeCertificationRepository;
+    private final GcsService gcsService;
+
 
     //이 메서드는 Mobeom Excel dataset 파싱을 통해 가게 이름과 주소를 얻고, 이 정보를 바탕으로 Google Map Place Id를 가져옵니다.
     //그 후 얻어진 Google Map Place Id를 가지고 가게 상세 정보를 Google Map API로부터 가져와 Store DB에 저장합니다.
@@ -96,8 +101,24 @@ public class MobeomGoogleMapStoreService {
                         continue;
 
                     if (!googlePhotosList.isEmpty()) {  //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                        localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey));
-                        googlePhotosList.remove(0);
+                        if (currentProfile.equals("dev")) {
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            if (googleMapPlacesImageAsBytes != null) {
+                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
+                                localPhotosList.add(gcsPath);
+                                googlePhotosList.remove(0);
+                            }
+                        } else if (currentProfile.equals("prod")) {
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            if (googleMapPlacesImageAsBytes != null) {
+                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
+                                localPhotosList.add(gcsPath);
+                                googlePhotosList.remove(0);
+                            }
+                        } else {    //local이나 test 시
+                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey));
+                            googlePhotosList.remove(0);
+                        }
                     }
 
                     //얻어온 가게 상세 정보를 바탕으로 DB에 저장할 객체를 생성
@@ -255,11 +276,30 @@ public class MobeomGoogleMapStoreService {
                             return createDividedMobeomStoresResponse;
                         }
                         //돈이 충분히 있으면,
-                        localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                        googlePhotosList.remove(0);
-
-                        //소비한 비용 반영
-                        dollars -= 0.007;
+                        if (currentProfile.equals("dev")) {
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            if (googleMapPlacesImageAsBytes != null) {
+                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
+                                localPhotosList.add(gcsPath);
+                                googlePhotosList.remove(0);
+                                //소비한 비용 반영
+                                dollars -= 0.007;
+                            }
+                        } else if (currentProfile.equals("prod")) {
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            if (googleMapPlacesImageAsBytes != null) {
+                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
+                                localPhotosList.add(gcsPath);
+                                googlePhotosList.remove(0);
+                                //소비한 비용 반영
+                                dollars -= 0.007;
+                            }
+                        } else {    //local이나 test 시
+                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
+                            googlePhotosList.remove(0);
+                            //소비한 비용 반영
+                            dollars -= 0.007;
+                        }
                     }
 
                     //얻어온 가게 상세 정보를 바탕으로 DB에 저장할 객체를 생성

--- a/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
@@ -1,6 +1,6 @@
 package com.nainga.nainga.domain.store.application;
 
-import com.google.gson.*;
+import com.google.gson.JsonObject;
 import com.nainga.nainga.domain.certification.dao.CertificationRepository;
 import com.nainga.nainga.domain.certification.domain.Certification;
 import com.nainga.nainga.domain.store.dao.StoreRepository;
@@ -22,17 +22,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import static com.nainga.nainga.domain.store.application.GoogleMapMethods.*;
 

--- a/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +42,17 @@ public class MobeomGoogleMapStoreService {
     private final CertificationRepository certificationRepository;
     private final StoreCertificationRepository storeCertificationRepository;
     private final GcsService gcsService;
+
+    //아래 생성자 주입을 별도로 작성한 이유는 특정 Profile에서만 의존성 주입이 필요한 GcsService에 @Autowired(required = false)를 적용해주기 위해
+    @Autowired
+    public MobeomGoogleMapStoreService(@Value("${GOOGLE_API_KEY}") String googleApiKey,@Value("${CURRENT_PROFILE}") String currentProfile, StoreRepository storeRepository, CertificationRepository certificationRepository, StoreCertificationRepository storeCertificationRepository, @Autowired(required = false) GcsService gcsService) {
+        this.googleApiKey = googleApiKey;
+        this.currentProfile = currentProfile;
+        this.storeRepository = storeRepository;
+        this.certificationRepository = certificationRepository;
+        this.storeCertificationRepository = storeCertificationRepository;
+        this.gcsService = gcsService;
+    }
 
 
     //이 메서드는 Mobeom Excel dataset 파싱을 통해 가게 이름과 주소를 얻고, 이 정보를 바탕으로 Google Map Place Id를 가져옵니다.

--- a/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
@@ -3,6 +3,7 @@ package com.nainga.nainga.domain.store.application;
 import com.google.gson.JsonObject;
 import com.nainga.nainga.domain.certification.dao.CertificationRepository;
 import com.nainga.nainga.domain.certification.domain.Certification;
+import com.nainga.nainga.domain.gcsguide.GcsService;
 import com.nainga.nainga.domain.store.dao.StoreRepository;
 import com.nainga.nainga.domain.store.domain.Store;
 import com.nainga.nainga.domain.store.domain.StoreDay;
@@ -34,9 +35,12 @@ import static com.nainga.nainga.domain.store.application.GoogleMapMethods.*;
 public class SafeGoogleMapStoreService {
     @Value("${GOOGLE_API_KEY}")
     private String googleApiKey;    //Spring bean 내에서만 @Value로 프로퍼티를 가져올 수 있어서 Service 단에서 받고 GoogleMapMethods에는 파라미터로 넘겨줌.
+    @Value("${CURRENT_PROFILE}")
+    private String currentProfile;  //현재 Active Profile을 조회
     private final StoreRepository storeRepository;
     private final CertificationRepository certificationRepository;
     private final StoreCertificationRepository storeCertificationRepository;
+    private final GcsService gcsService;
 
     //이 메서드는 Safe Excel dataset 파싱을 통해 가게 이름과 주소를 얻고, 이 정보를 바탕으로 Google Map Place Id를 가져옵니다.
     //그 후 얻어진 Google Map Place Id를 가지고 가게 상세 정보를 Google Map API로부터 가져와 Store DB에 저장합니다.
@@ -96,8 +100,24 @@ public class SafeGoogleMapStoreService {
                         continue;
 
                     if (!googlePhotosList.isEmpty()) {  //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                        localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey));
-                        googlePhotosList.remove(0);
+                        if (currentProfile.equals("dev")) {
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            if (googleMapPlacesImageAsBytes != null) {
+                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
+                                localPhotosList.add(gcsPath);
+                                googlePhotosList.remove(0);
+                            }
+                        } else if (currentProfile.equals("prod")) {
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            if (googleMapPlacesImageAsBytes != null) {
+                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
+                                localPhotosList.add(gcsPath);
+                                googlePhotosList.remove(0);
+                            }
+                        } else {    //local이나 test 시
+                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey));
+                            googlePhotosList.remove(0);
+                        }
                     }
 
                     //얻어온 가게 상세 정보를 바탕으로 DB에 저장할 객체를 생성
@@ -255,11 +275,30 @@ public class SafeGoogleMapStoreService {
                             return createDividedSafeStoresResponse;
                         }
                         //돈이 충분히 있으면,
-                        localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                        googlePhotosList.remove(0);
-
-                        //소비한 비용 반영
-                        dollars -= 0.007;
+                        if (currentProfile.equals("dev")) {
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            if (googleMapPlacesImageAsBytes != null) {
+                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
+                                localPhotosList.add(gcsPath);
+                                googlePhotosList.remove(0);
+                                //소비한 비용 반영
+                                dollars -= 0.007;
+                            }
+                        } else if (currentProfile.equals("prod")) {
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            if (googleMapPlacesImageAsBytes != null) {
+                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
+                                localPhotosList.add(gcsPath);
+                                googlePhotosList.remove(0);
+                                //소비한 비용 반영
+                                dollars -= 0.007;
+                            }
+                        } else {    //local이나 test 시
+                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
+                            googlePhotosList.remove(0);
+                            //소비한 비용 반영
+                            dollars -= 0.007;
+                        }
                     }
 
                     //얻어온 가게 상세 정보를 바탕으로 DB에 저장할 객체를 생성

--- a/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
@@ -96,7 +96,7 @@ public class SafeGoogleMapStoreService {
                         continue;
 
                     if (!googlePhotosList.isEmpty()) {  //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                        localPhotosList.add(getGoogleMapPlacesImage(googlePhotosList.get(0), googleApiKey));
+                        localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey));
                         googlePhotosList.remove(0);
                     }
 
@@ -255,7 +255,7 @@ public class SafeGoogleMapStoreService {
                             return createDividedSafeStoresResponse;
                         }
                         //돈이 충분히 있으면,
-                        localPhotosList.add(getGoogleMapPlacesImage(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
+                        localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
                         googlePhotosList.remove(0);
 
                         //소비한 비용 반영

--- a/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
@@ -112,14 +112,7 @@ public class SafeGoogleMapStoreService {
                         continue;
 
                     if (!googlePhotosList.isEmpty()) {  //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                        if (currentProfile.equals("dev")) {
-                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
-                            if (googleMapPlacesImageAsBytes != null) {
-                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
-                                localPhotosList.add(gcsPath);
-                                googlePhotosList.remove(0);
-                            }
-                        } else if (currentProfile.equals("prod")) {
+                        if (currentProfile.equals("dev") || currentProfile.equals("prod")) {
                             byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
                             if (googleMapPlacesImageAsBytes != null) {
                                 String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
@@ -287,16 +280,7 @@ public class SafeGoogleMapStoreService {
                             return createDividedSafeStoresResponse;
                         }
                         //돈이 충분히 있으면,
-                        if (currentProfile.equals("dev")) {
-                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
-                            if (googleMapPlacesImageAsBytes != null) {
-                                String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
-                                localPhotosList.add(gcsPath);
-                                googlePhotosList.remove(0);
-                                //소비한 비용 반영
-                                dollars -= 0.007;
-                            }
-                        } else if (currentProfile.equals("prod")) {
+                        if (currentProfile.equals("dev") || currentProfile.equals("prod")) {
                             byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
                             if (googleMapPlacesImageAsBytes != null) {
                                 String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);

--- a/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +42,17 @@ public class SafeGoogleMapStoreService {
     private final CertificationRepository certificationRepository;
     private final StoreCertificationRepository storeCertificationRepository;
     private final GcsService gcsService;
+
+    //아래 생성자 주입을 별도로 작성한 이유는 특정 Profile에서만 의존성 주입이 필요한 GcsService에 @Autowired(required = false)를 적용해주기 위해
+    @Autowired
+    public SafeGoogleMapStoreService(@Value("${GOOGLE_API_KEY}") String googleApiKey,@Value("${CURRENT_PROFILE}") String currentProfile, StoreRepository storeRepository, CertificationRepository certificationRepository, StoreCertificationRepository storeCertificationRepository, @Autowired(required = false) GcsService gcsService) {
+        this.googleApiKey = googleApiKey;
+        this.currentProfile = currentProfile;
+        this.storeRepository = storeRepository;
+        this.certificationRepository = certificationRepository;
+        this.storeCertificationRepository = storeCertificationRepository;
+        this.gcsService = gcsService;
+    }
 
     //이 메서드는 Safe Excel dataset 파싱을 통해 가게 이름과 주소를 얻고, 이 정보를 바탕으로 Google Map Place Id를 가져옵니다.
     //그 후 얻어진 Google Map Place Id를 가지고 가게 상세 정보를 Google Map API로부터 가져와 Store DB에 저장합니다.

--- a/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
@@ -1,6 +1,6 @@
 package com.nainga.nainga.domain.store.application;
 
-import com.google.gson.*;
+import com.google.gson.JsonObject;
 import com.nainga.nainga.domain.certification.dao.CertificationRepository;
 import com.nainga.nainga.domain.certification.domain.Certification;
 import com.nainga.nainga.domain.store.dao.StoreRepository;
@@ -22,17 +22,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import static com.nainga.nainga.domain.store.application.GoogleMapMethods.*;
 

--- a/src/main/java/com/nainga/nainga/domain/store/dao/StoreRepository.java
+++ b/src/main/java/com/nainga/nainga/domain/store/dao/StoreRepository.java
@@ -1,9 +1,7 @@
 package com.nainga.nainga.domain.store.dao;
 
-import com.nainga.nainga.domain.store.domain.Location;
 import com.nainga.nainga.domain.store.domain.Store;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
@@ -1,22 +1,21 @@
 package com.nainga.nainga.domain.storecertification.api;
 
 import com.nainga.nainga.domain.store.domain.Location;
-import com.nainga.nainga.domain.store.domain.Store;
 import com.nainga.nainga.domain.storecertification.application.StoreCertificationService;
 import com.nainga.nainga.domain.storecertification.domain.StoreCertification;
-import com.nainga.nainga.domain.storecertification.dto.StoreCertificationsByLocationRequest;
 import com.nainga.nainga.domain.storecertification.dto.StoreCertificationsByLocationResponse;
 import com.nainga.nainga.global.util.Result;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
@@ -24,7 +24,24 @@ public class StoreCertificationApi {
 
     //북서쪽, 남동쪽 좌표를 받아 두 좌표로 만들어지는 가장 작은 사각형 내 모든 가게 상세 정보를 반환
     @Tag(name = "가게 상세 정보")
-    @Operation(summary = "사용자 위치 기반 가게 상세 정보 제공", description = "사용자 위치를 기준으로 좌상단, 우하단 위도 경도 좌표를 넘겨 받아 두 좌표로 만들 수 있는 최소 크기의 사각형 범위 내 모든 가게의 상세 정보를 전달해줍니다.")
+    @Operation(summary = "사용자 위치 기반 가게 상세 정보 제공", description = "사용자 위치를 기준으로 좌상단, 우하단 위도 경도 좌표를 넘겨 받아 두 좌표로 만들 수 있는 최소 크기의 사각형 범위 내 모든 가게의 상세 정보를 전달해줍니다.<br><br>" +
+            "[Request Body]<br>" +
+            "nwLong: 북서쪽 좌표 경도<br>" +
+            "nwLat: 북서쪽 좌표 위도<br>" +
+            "seLong: 남동쪽 좌표 경도<br>" +
+            "seLat: 남동쪽 좌표 위도<br><br>" +
+            "[Response Body]<br>" +
+            "id: Database 내 Primary Key값<br>" +
+            "displayName: 가게 이름<br>" +
+            "primaryTypeDisplayName: 업종<br>" +
+            "formattedAddress: 주소<br>" +
+            "phoneNumber: 전화번호<br>" +
+            "location: (경도, 위도) 가게 좌표<br>" +
+            "regularOpeningHours: 영업 시간<br>" +
+            "=> 특정 요일이 휴무인 경우에는 해당 요일에 대한 데이터가 들어있지 않습니다. Break time이 있는 경우 동일한 요일에 대해 영업 시간 데이터가 여러 개 존재할 수 있습니다. <br>" +
+            "localPhotos: 저장된 가게 사진 URL<br>" +
+            "certificationName: 가게의 인증제 목록<br>" +
+            "=> 각 인증제별 순서는 보장되지 않습니다.")
     @GetMapping("api/v1/storecertification/byLocation")
     public Result<List<StoreCertificationsByLocationResponse>> findStoreCertificationsByLocation(@RequestParam("nwLong") double nwLong, @RequestParam("nwLat") double nwLat, @RequestParam("seLong") double seLong, @RequestParam("seLat") double seLat) {
         List<StoreCertification> storeCertificationsByLocation = storeCertificationService.findStoreCertificationsByLocation(new Location(nwLong, nwLat), new Location(seLong, seLat));

--- a/src/main/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationService.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
@@ -1,7 +1,6 @@
 package com.nainga.nainga.domain.storecertification.dao;
 
 import com.nainga.nainga.domain.store.domain.Location;
-import com.nainga.nainga.domain.store.domain.Store;
 import com.nainga.nainga.domain.storecertification.domain.StoreCertification;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;

--- a/src/main/java/com/nainga/nainga/domain/storecertification/domain/StoreCertification.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/domain/StoreCertification.java
@@ -1,7 +1,7 @@
 package com.nainga.nainga.domain.storecertification.domain;
 
-import com.nainga.nainga.domain.store.domain.Store;
 import com.nainga.nainga.domain.certification.domain.Certification;
+import com.nainga.nainga.domain.store.domain.Store;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/nainga/nainga/domain/storecertification/dto/StoreCertificationsByLocationResponse.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/dto/StoreCertificationsByLocationResponse.java
@@ -1,7 +1,6 @@
 package com.nainga.nainga.domain.storecertification.dto;
 
 import com.nainga.nainga.domain.store.domain.Location;
-import com.nainga.nainga.domain.store.domain.Store;
 import com.nainga.nainga.domain.store.domain.StoreRegularOpeningHours;
 import com.nainga.nainga.domain.storecertification.domain.StoreCertification;
 import lombok.Data;

--- a/src/test/java/com/nainga/nainga/NaingaApplicationTests.java
+++ b/src/test/java/com/nainga/nainga/NaingaApplicationTests.java
@@ -2,7 +2,6 @@ package com.nainga.nainga;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 class NaingaApplicationTests {

--- a/src/test/java/com/nainga/nainga/domain/store/application/GoodPriceDataParserTest.java
+++ b/src/test/java/com/nainga/nainga/domain/store/application/GoodPriceDataParserTest.java
@@ -1,18 +1,12 @@
 package com.nainga.nainga.domain.store.application;
 
 import com.nainga.nainga.domain.store.dto.StoreDataByParser;
-import org.apache.commons.io.FilenameUtils;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class GoodPriceDataParserTest {

--- a/src/test/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreServiceTest.java
+++ b/src/test/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreServiceTest.java
@@ -8,7 +8,6 @@ import com.nainga.nainga.domain.store.dto.CreateDividedGoodPriceStoresResponse;
 import com.nainga.nainga.domain.storecertification.dao.StoreCertificationRepository;
 import com.nainga.nainga.domain.storecertification.domain.StoreCertification;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/test/java/com/nainga/nainga/domain/store/application/MobeomDataParserTest.java
+++ b/src/test/java/com/nainga/nainga/domain/store/application/MobeomDataParserTest.java
@@ -1,18 +1,12 @@
 package com.nainga.nainga.domain.store.application;
 
 import com.nainga.nainga.domain.store.dto.StoreDataByParser;
-import org.apache.commons.io.FilenameUtils;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class MobeomDataParserTest {

--- a/src/test/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreServiceTest.java
+++ b/src/test/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreServiceTest.java
@@ -8,7 +8,6 @@ import com.nainga.nainga.domain.store.dto.CreateDividedMobeomStoresResponse;
 import com.nainga.nainga.domain.storecertification.dao.StoreCertificationRepository;
 import com.nainga.nainga.domain.storecertification.domain.StoreCertification;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/test/java/com/nainga/nainga/domain/store/application/SafeDataParserTest.java
+++ b/src/test/java/com/nainga/nainga/domain/store/application/SafeDataParserTest.java
@@ -1,18 +1,12 @@
 package com.nainga.nainga.domain.store.application;
 
 import com.nainga.nainga.domain.store.dto.StoreDataByParser;
-import org.apache.commons.io.FilenameUtils;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class SafeDataParserTest {

--- a/src/test/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreServiceTest.java
+++ b/src/test/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreServiceTest.java
@@ -8,7 +8,6 @@ import com.nainga.nainga.domain.store.dto.CreateDividedSafeStoresResponse;
 import com.nainga.nainga.domain.storecertification.dao.StoreCertificationRepository;
 import com.nainga.nainga.domain.storecertification.domain.StoreCertification;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/test/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationServiceTest.java
+++ b/src/test/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationServiceTest.java
@@ -7,11 +7,9 @@ import com.nainga.nainga.domain.store.domain.Store;
 import com.nainga.nainga.domain.storecertification.dao.StoreCertificationRepository;
 import com.nainga.nainga.domain.storecertification.domain.StoreCertification;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;


### PR DESCRIPTION
## ⭐️ Issue Number

- #54 

## 🚩 Summary
가게 이미지를 저장하는 로직에서 지금까지는 Cloud storage가 생성되지 않아서 Local에 저장하는 방식을 취했었는데 Google Cloud Storage(GCS)가 구축됨에 따라 해당 로직을 GCS에 저장하는 방식으로 변경합니다.

- [x] 기존에 모두 Local에 저장하던 방식을 dev, prod profile의 경우 각각 맞는 GCS에 저장하도록 변경
- [x] 저장된 이미지를 불러올 수 있는 API 구현
- [x] Swagger Description 상세 설명 추가


## 🛠️ Technical Concerns

### Optional한 Spring Bean 주입
현재 요구 사항에 따르면 Development, Production 배포 환경에서만 Google Cloud Storage를 사용하고 Local, Test 환경에서는 Local 환경에 이미지를 저장하도록 되어있습니다. 그래서 선택적으로 Dev, Prod 환경에서만 GCS 관련 Service 로직을 사용하게 되는데, 해당 서비스 로직은 공통 서비스 로직인 GoogleMapService 로직에 들어가있습니다.

이때, GcsService는 Profile({"dev", "prod"}) 애너테이션에 따라 특정 프로파일에서만 Bean이 생성되기 때문에 local, test 환경에서 Spring Project를 실행시키면 해당 Bean이 생성되지 않아 의존성 주입이 되지 않아 발생하는 Exception error가 있었습니다.

이를 해결하기 위해서는 선택적으로 의존성 주입이 필요했는데, 이를 위해 기존에 사용하던 필드 의존성 주입을 명시적 생성자 주입으로 바꾸고 Optional하게 필요했던 GcsService 파라미터에 대해서는 Autowired(required=false) 애너테이션을 붙여서 해당 Bean이 생성되지 않았을  때도 컴파일 에러를 뱉지 않도록 수정하였습니다.

## 📋 To Do

- 대용량 데이터 셋을 자동으로 생성하기 위한 로직 개발
- Production 배포를 위해 Release 브랜치를 거쳐 Main으로 머지
- Production level에서 가게 데이터 주입
