### PR TITLE
가게 조회 API에 가게 더보기 기능 구현 (#78)

### DIFF
--- a/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
@@ -68,6 +68,9 @@ public class StoreCertificationApi {
         });
 
         List<List<StoreCertificationsByLocationResponse>> storeCertificationsByLocationListResponses = new ArrayList<>();
+        if (storeCertificationsByLocationResponses.size() == 0) {   //size가 0일 때 예외 처리를 안해주면, 밑에 난수 뽑을 때 ints 메서드에서 boundary exception 발생
+            return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, storeCertificationsByLocationListResponses);
+        }
 
         //아래 로직은 Multi threads 환경에도 safe한 ThreadLocalRandom을 통해 영역 안에 들어가는 전체 가게 리스트 중 랜덤하게 최대 75개를 뽑는 과정
         int[] randomInts = ThreadLocalRandom.current()

--- a/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
@@ -76,7 +76,7 @@ public class StoreCertificationApi {
         int[] randomInts = ThreadLocalRandom.current()
                 .ints(0, storeCertificationsByLocationResponses.size())
                 .distinct()
-                .limit(75)
+                .limit(Math.min(storeCertificationsByLocationResponses.size(), 75)) //여기서 limit를 75로만 설정해버리면, 검색 결과의 사이즈가 75개보다 작을 때 무한 루프가 돔
                 .toArray();
 
         int count = 0;


### PR DESCRIPTION
## ⭐️ Issue Number

- #78 

## 🚩 Summary
가게 상세 정보 조회 API의 요구 사항이 변경됨에 따라 보여질 수 있는 데이터 양에따라 최대 5회차까지 각 회차당 15개씩 데이터를 보여주는 방식으로 변경합니다.
이를 구현하기 위해 백엔드 단에서는 클라이언트 단에서 요청하는 영역의 데이터 중 랜덤하게 최대 75개를 뽑고 이를 총 5회차로 나누어 배열에 담아 한번에 보내주도록 수정합니다.

## 🛠️ Technical Concerns

### Java 난수 생성

Java에서 난수를 생성하는 방법으로는 크게 Random 클래스를 활용하는 방법과 ThreadLocalRandom 클래스를 활용하는 방법, 이렇게 총 2가지가 있습니다.

그 중에서도 저는 ThreadLocalRandom 클래스를 사용했는데 그 이유는 다음과 같습니다.

일단 Java 1 버전부터 존재했던 Random 클래스는 Thread-safe하지만, 멀티 스레드 환경과 같이 여러 쓰레드에서 동시 접근하면 경합이 발생하여 성능이 저하되는 이슈가 있었습니다.
이를 개선해서 Java 7 버전부터 나온 것이 ThreadLocalRandom 클래스 입니다.
이는 쓰레드별로 seed값을 다르게 관리해서 Random보다 쓰레드에 대해 응답이 빠르고 멀티 스레드 환경에서도 thread-safe하다는 장점을 가지고 있어서 Java 7 버전부터는 사실 안쓸 이유가 없었습니다.

<img width="1189" alt="Screenshot 2024-02-02 at 5 50 25 PM" src="https://github.com/Korea-Certified-Store/backend/assets/77658361/22db855f-87e1-40ee-9416-78e7cfb35ed8">

저는 위와 같이 코드를 구현하였는데, 이중에서 ThreadLocalRandom 내 limit 부분에서 처음에 무한 루프가 도는 문제가 있었습니다.

제가 난수를 뽑는 대상의 List의 size가 제가 지정한 75개보다 작게되면 limit 메서드는 어떻게든 75개를 뽑으려고 하는데 제가 distinct() 메서드까지 걸어놔서 중복 없이 뽑는 것이 불가능해져 계속 무한 루프가 도는 것을 확인하였고 이는 간단하게 min 메서드 활용해서 limit를 size와 75 중 minimum 값을 사용하도록 구현해줬습니다.

또 다음으로 발생했던 이슈로는 ThreadLocalRandom 내 ints() 메서드의 Boundary exception입니다.
해당 메서드의 첫 번째 파라미터로 들어가는 randomNumberOrigin 파라미터 값이 두 번째 파라미터 값보다 항상 작아야되는 처리가 되어 있었는데 처음에 이를 인지하지 못하고 별도의 처리를 해주지 않아서 size()가 0일 때도 ints(0,0) 이런 식으로 메서드가 실행되어 Boundary exception이 발생했던 문제가 있습니다.

이 문제도 역시 간단하게 size()가 0일 떄는 바로 return 처리하여 해당 로직을 타지 않도록 수정해줬습니다.

<img width="978" alt="Screenshot 2024-02-02 at 5 43 56 PM" src="https://github.com/Korea-Certified-Store/backend/assets/77658361/b1d4c2ee-9fff-4954-8a76-ef2cb064d609">

이렇게 구현한 난수 추출 로직에 대해서 가장 큰 사이즈의 데이터 셋이 들어갔을 때 어느정도의 속도로 처리해줄 수 있는지 간단히 처리 속도 검사를 해봤는데 약 0~3 ms 안에서 끝나는 것을 확인할 수 있었습니다. 

## 📋 To Do

- 바로 머지가 필요한 상황이라, Code review를 받은 뒤 곧바로 Develop to Main 릴리즈를 진행할 계획입니다.
