### PR TITLE
N+1 문제 해결 및 성능 개선 (#82)

### DIFF
--- a/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
@@ -295,7 +295,8 @@ public class GoodPriceGoogleMapStoreService {
                                 if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
                                     iterator.next();
                                     iterator.remove();
-                                }                                //소비한 비용 반영
+                                }
+                                //소비한 비용 반영
                                 dollars -= 0.007;
                             }
                         } else {    //local이나 test 시
@@ -304,7 +305,8 @@ public class GoodPriceGoogleMapStoreService {
                             if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
                                 iterator.next();
                                 iterator.remove();
-                            }                            //소비한 비용 반영
+                            }
+                            //소비한 비용 반영
                             dollars -= 0.007;
                         }
                     }

--- a/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/GoodPriceGoogleMapStoreService.java
@@ -24,9 +24,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static com.nainga.nainga.domain.store.application.GoogleMapMethods.*;
 
@@ -78,10 +76,10 @@ public class GoodPriceGoogleMapStoreService {
 
                 //WKTReader Parse exception에 대한 처리를 위한 try-catch문
                 try {
-                    List<StoreRegularOpeningHours> regularOpeningHours;
-                    List<String> weekdayDescriptions = new ArrayList<>();
-                    List<String> localPhotosList = new ArrayList<>();
-                    List<String> googlePhotosList = new ArrayList<>();
+                    Set<StoreRegularOpeningHours> regularOpeningHours;
+                    Set<String> weekdayDescriptions = new LinkedHashSet<>();
+                    Set<String> localPhotosList = new LinkedHashSet<>();
+                    Set<String> googlePhotosList = new LinkedHashSet<>();
                     String phoneNumber = null;
                     String primaryTypeDisplayName = null;
 
@@ -113,15 +111,23 @@ public class GoodPriceGoogleMapStoreService {
 
                     if (!googlePhotosList.isEmpty()) {  //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
                         if (currentProfile.equals("dev") || currentProfile.equals("prod")) {
-                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.stream().findFirst().get(), googleApiKey);
                             if (googleMapPlacesImageAsBytes != null) {
                                 String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
                                 localPhotosList.add(gcsPath);
-                                googlePhotosList.remove(0);
+                                Iterator<String> iterator = googlePhotosList.iterator();
+                                if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
+                                    iterator.next();
+                                    iterator.remove();
+                                }
                             }
                         } else {    //local이나 test 시
-                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey));
-                            googlePhotosList.remove(0);
+                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.stream().findFirst().get(), googleApiKey));
+                            Iterator<String> iterator = googlePhotosList.iterator();
+                            if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
+                                iterator.next();
+                                iterator.remove();
+                            }
                         }
                     }
 
@@ -239,10 +245,10 @@ public class GoodPriceGoogleMapStoreService {
 
                 //WKTReader Parse exception에 대한 처리를 위한 try-catch문
                 try {
-                    List<StoreRegularOpeningHours> regularOpeningHours;
-                    List<String> weekdayDescriptions = new ArrayList<>();
-                    List<String> localPhotosList = new ArrayList<>();
-                    List<String> googlePhotosList = new ArrayList<>();
+                    Set<StoreRegularOpeningHours> regularOpeningHours;
+                    Set<String> weekdayDescriptions = new LinkedHashSet<>();
+                    Set<String> localPhotosList = new LinkedHashSet<>();
+                    Set<String> googlePhotosList = new LinkedHashSet<>();
                     String phoneNumber = null;
                     String primaryTypeDisplayName = null;
 
@@ -281,18 +287,24 @@ public class GoodPriceGoogleMapStoreService {
                         }
                         //돈이 충분히 있으면,
                         if (currentProfile.equals("dev") || currentProfile.equals("prod")) {
-                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.stream().findFirst().get(), googleApiKey);
                             if (googleMapPlacesImageAsBytes != null) {
                                 String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
                                 localPhotosList.add(gcsPath);
-                                googlePhotosList.remove(0);
-                                //소비한 비용 반영
+                                Iterator<String> iterator = googlePhotosList.iterator();
+                                if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
+                                    iterator.next();
+                                    iterator.remove();
+                                }                                //소비한 비용 반영
                                 dollars -= 0.007;
                             }
                         } else {    //local이나 test 시
-                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                            googlePhotosList.remove(0);
-                            //소비한 비용 반영
+                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.stream().findFirst().get(), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
+                            Iterator<String> iterator = googlePhotosList.iterator();
+                            if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
+                                iterator.next();
+                                iterator.remove();
+                            }                            //소비한 비용 반영
                             dollars -= 0.007;
                         }
                     }
@@ -380,8 +392,8 @@ public class GoodPriceGoogleMapStoreService {
 
     //Google Map API에서 제공해주는 영업 시간 정보가 periods와 weekdayDescriptions 방식이 있는데, 기존에 구조화된 periods를 사용했었지만 데이터가 깨져있는 경우가 종종 있어서,
     //조금 더 안정적인 weekdayDescriptions으로 데이터를 받아오고 직접 파싱해서 periods 식으로 변환하여 저장하기 위함
-    public List<StoreRegularOpeningHours> parseWeekdayDescriptions(List<String> weekdayDescriptions) {
-        List<StoreRegularOpeningHours> storeRegularOpeningHoursList = new ArrayList<>();
+    public Set<StoreRegularOpeningHours> parseWeekdayDescriptions(Set<String> weekdayDescriptions) {
+        Set<StoreRegularOpeningHours> storeRegularOpeningHoursList = new LinkedHashSet<>();
 
         for (String weekdayDescription : weekdayDescriptions) {
             weekdayDescription = weekdayDescription.replace(",", " ");   //,는 제거

--- a/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/MobeomGoogleMapStoreService.java
@@ -296,7 +296,8 @@ public class MobeomGoogleMapStoreService {
                                 if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
                                     iterator.next();
                                     iterator.remove();
-                                }                                //소비한 비용 반영
+                                }
+                                //소비한 비용 반영
                                 dollars -= 0.007;
                             }
                         } else {    //local이나 test 시
@@ -305,7 +306,8 @@ public class MobeomGoogleMapStoreService {
                             if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
                                 iterator.next();
                                 iterator.remove();
-                            }                            //소비한 비용 반영
+                            }
+                            //소비한 비용 반영
                             dollars -= 0.007;
                         }
                     }

--- a/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
+++ b/src/main/java/com/nainga/nainga/domain/store/application/SafeGoogleMapStoreService.java
@@ -24,9 +24,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static com.nainga.nainga.domain.store.application.GoogleMapMethods.*;
 
@@ -78,10 +76,10 @@ public class SafeGoogleMapStoreService {
 
                 //WKTReader Parse exception에 대한 처리를 위한 try-catch문
                 try {
-                    List<StoreRegularOpeningHours> regularOpeningHours;
-                    List<String> weekdayDescriptions = new ArrayList<>();
-                    List<String> localPhotosList = new ArrayList<>();
-                    List<String> googlePhotosList = new ArrayList<>();
+                    Set<StoreRegularOpeningHours> regularOpeningHours;
+                    Set<String> weekdayDescriptions = new LinkedHashSet<>();
+                    Set<String> localPhotosList = new LinkedHashSet<>();
+                    Set<String> googlePhotosList = new LinkedHashSet<>();
                     String phoneNumber = null;
                     String primaryTypeDisplayName = null;
 
@@ -113,15 +111,23 @@ public class SafeGoogleMapStoreService {
 
                     if (!googlePhotosList.isEmpty()) {  //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
                         if (currentProfile.equals("dev") || currentProfile.equals("prod")) {
-                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.stream().findFirst().get(), googleApiKey);
                             if (googleMapPlacesImageAsBytes != null) {
                                 String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
                                 localPhotosList.add(gcsPath);
-                                googlePhotosList.remove(0);
+                                Iterator<String> iterator = googlePhotosList.iterator();
+                                if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
+                                    iterator.next();
+                                    iterator.remove();
+                                }
                             }
                         } else {    //local이나 test 시
-                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey));
-                            googlePhotosList.remove(0);
+                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.stream().findFirst().get(), googleApiKey));
+                            Iterator<String> iterator = googlePhotosList.iterator();
+                            if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
+                                iterator.next();
+                                iterator.remove();
+                            }
                         }
                     }
 
@@ -239,10 +245,10 @@ public class SafeGoogleMapStoreService {
 
                 //WKTReader Parse exception에 대한 처리를 위한 try-catch문
                 try {
-                    List<StoreRegularOpeningHours> regularOpeningHours;
-                    List<String> weekdayDescriptions = new ArrayList<>();
-                    List<String> localPhotosList = new ArrayList<>();
-                    List<String> googlePhotosList = new ArrayList<>();
+                    Set<StoreRegularOpeningHours> regularOpeningHours;
+                    Set<String> weekdayDescriptions = new LinkedHashSet<>();
+                    Set<String> localPhotosList = new LinkedHashSet<>();
+                    Set<String> googlePhotosList = new LinkedHashSet<>();
                     String phoneNumber = null;
                     String primaryTypeDisplayName = null;
 
@@ -281,17 +287,25 @@ public class SafeGoogleMapStoreService {
                         }
                         //돈이 충분히 있으면,
                         if (currentProfile.equals("dev") || currentProfile.equals("prod")) {
-                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.get(0), googleApiKey);
+                            byte[] googleMapPlacesImageAsBytes = getGoogleMapPlacesImageAsBytes(googlePhotosList.stream().findFirst().get(), googleApiKey);
                             if (googleMapPlacesImageAsBytes != null) {
                                 String gcsPath = gcsService.uploadImage(googleMapPlacesImageAsBytes);
                                 localPhotosList.add(gcsPath);
-                                googlePhotosList.remove(0);
+                                Iterator<String> iterator = googlePhotosList.iterator();
+                                if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
+                                    iterator.next();
+                                    iterator.remove();
+                                }
                                 //소비한 비용 반영
                                 dollars -= 0.007;
                             }
                         } else {    //local이나 test 시
-                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.get(0), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
-                            googlePhotosList.remove(0);
+                            localPhotosList.add(getGoogleMapPlacesImageToLocal(googlePhotosList.stream().findFirst().get(), googleApiKey)); //가장 첫 번째 사진만 실제로 다운로드까지 진행하고 나머지는 나중에 쓸 용도로 googlePhotosList에 저장
+                            Iterator<String> iterator = googlePhotosList.iterator();
+                            if (iterator.hasNext()) {   //googlePhotosList에서 가장 첫 번째 원소를 제거
+                                iterator.next();
+                                iterator.remove();
+                            }
                             //소비한 비용 반영
                             dollars -= 0.007;
                         }
@@ -380,8 +394,8 @@ public class SafeGoogleMapStoreService {
 
     //Google Map API에서 제공해주는 영업 시간 정보가 periods와 weekdayDescriptions 방식이 있는데, 기존에 구조화된 periods를 사용했었지만 데이터가 깨져있는 경우가 종종 있어서,
     //조금 더 안정적인 weekdayDescriptions으로 데이터를 받아오고 직접 파싱해서 periods 식으로 변환하여 저장하기 위함
-    public List<StoreRegularOpeningHours> parseWeekdayDescriptions(List<String> weekdayDescriptions) {
-        List<StoreRegularOpeningHours> storeRegularOpeningHoursList = new ArrayList<>();
+    public Set<StoreRegularOpeningHours> parseWeekdayDescriptions(Set<String> weekdayDescriptions) {
+        Set<StoreRegularOpeningHours> storeRegularOpeningHoursList = new LinkedHashSet<>();
 
         for (String weekdayDescription : weekdayDescriptions) {
             weekdayDescription = weekdayDescription.replace(",", " ");   //,는 제거

--- a/src/main/java/com/nainga/nainga/domain/store/domain/Store.java
+++ b/src/main/java/com/nainga/nainga/domain/store/domain/Store.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.locationtech.jts.geom.Point;
 
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -26,11 +27,11 @@ public class Store {
     @Column(columnDefinition = "GEOMETRY")
     private Point location;    //(경도, 위도) 좌표
     @ElementCollection
-    private List<StoreRegularOpeningHours> regularOpeningHours;   //영업 시간
+    private Set<StoreRegularOpeningHours> regularOpeningHours;   //영업 시간
     @ElementCollection
-    private List<String> weekdayDescriptions;    //String 형식의 영업 시간
+    private Set<String> weekdayDescriptions;    //String 형식의 영업 시간
     @ElementCollection
-    private List<String> localPhotos;    //자체 DB에 저장된 가게 사진들
+    private Set<String> localPhotos;    //자체 DB에 저장된 가게 사진들
     @ElementCollection
-    private List<String> googlePhotos;  //나중에 Google Map API에서 더 가져와야하는 사진들
+    private Set<String> googlePhotos;  //나중에 Google Map API에서 더 가져와야하는 사진들
 }

--- a/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
@@ -4,6 +4,7 @@ import com.nainga.nainga.domain.store.domain.Location;
 import com.nainga.nainga.domain.storecertification.domain.StoreCertification;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -46,7 +47,14 @@ public class StoreCertificationRepository {
                 northWestLocation.getLongitude(), northWestLocation.getLatitude(), southWestLocation.getLongitude(), southWestLocation.getLatitude(), southEastLocation.getLongitude(), southEastLocation.getLatitude(), northEastLocation.getLongitude(), northEastLocation.getLatitude(), northWestLocation.getLongitude(), northWestLocation.getLatitude()
         );
 
-        Query query = em.createNativeQuery("SELECT sc.* " + "FROM store_certification AS sc " + "JOIN store AS s ON sc.store_id = s.store_id " + "JOIN certification AS c ON sc.certification_id = c.certification_id " + "WHERE ST_CONTAINS(ST_POLYGONFROMTEXT(" + pointFormat + "), s.location)", StoreCertification.class);
+        TypedQuery<StoreCertification> query = em.createQuery(
+                "SELECT sc FROM StoreCertification sc " +
+                        "JOIN FETCH sc.store s " +
+                        "JOIN FETCH sc.certification c " +
+                        "JOIN FETCH s.localPhotos sl " + // localPhotos를 Fetch Join
+                        "JOIN FETCH s.regularOpeningHours sr " + // regularOpeningHours를 Fetch Join
+                        "WHERE ST_CONTAINS(ST_POLYGONFROMTEXT(" + pointFormat + "), s.location)",
+                StoreCertification.class);
 
         return query.getResultList();
     }

--- a/src/main/java/com/nainga/nainga/domain/storecertification/dto/StoreCertificationsByLocationResponse.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/dto/StoreCertificationsByLocationResponse.java
@@ -7,6 +7,7 @@ import lombok.Data;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Data
 public class StoreCertificationsByLocationResponse {
@@ -16,8 +17,8 @@ public class StoreCertificationsByLocationResponse {
     String formattedAddress;    //가게 전체 주소
     String phoneNumber;    //전화번호
     Location location;    //(경도, 위도) 좌표
-    List<StoreRegularOpeningHours> regularOpeningHours;   //영업 시간
-    List<String> localPhotos;  //구글에서 실제로 다운로드 된 사진들, 현재까지는 최대 1장
+    Set<StoreRegularOpeningHours> regularOpeningHours;   //영업 시간
+    Set<String> localPhotos;  //구글에서 실제로 다운로드 된 사진들, 현재까지는 최대 1장
     List<String> certificationName;   //가지고 있는 인증제 이름 리스트
 
     public StoreCertificationsByLocationResponse(StoreCertification storeCertification) {


### PR DESCRIPTION
## ⭐️ Issue Number

- #82 

## 🚩 Summary
특정 영역 내의 가게 리스트들을 조회하는 API에서 총 3개의 테이블끼리 조인해서 가져오고 있는데 이 과정에서 N+1 문제가 발생하여 더 많은 부하를 주고 있는 것을 확인하였습니다.
이에 따라 Fetch Join을 활용해서 N+1 문제를 해결하고 성능을 개선하려 합니다.

- [x] 문제가 되는 API 관련 쿼리에 Fetch Join 적용
- [x] Refactoring 전 후 성능 비교 분석

## 🛠️ Technical Concerns

### N+1 문제

우선 Spring Data JPA 프로젝트를 진행하다보면 한번쯤은 꼭 듣는 N+1 문제가 저희 프로젝트에서도 발생하여 이와 관련한 공부와 Refactoring을 진행하였습니다.

사실 N+1 문제는 기존에도 이미 알고 대비를 해왔던 터라 저희 프로젝트에서는 발생하지 않을 줄 알았는데 ElementCollection 필드에 대해 예기치 못하게 N+1 문제가 발생한 것을 인지하고 이에 대한 개선 작업을 진행하였습니다.

원래 N+1 문제는 보통 연관 관계를 맺어줄 때 FetchType을 EAGER로 설정한 채 사용해서 발생하는데 이는 LAZY로 명시적으로 설정해주면 쉽게 해결이 가능하고, 필요에 따라 여러 엔티티를 한번에 조회해야하는 경우 Fetch Join 쿼리를 사용하면 됩니다.

하지만 이 과정에서 ElementCollection 애너테이션이 적용된 필드는 부모 엔티티에 대해 Fetch Join을 걸어도 별도로 해당 필드에 대해 명시적으로 Fetch Join을 걸어주지 않는 이상 Fetch Join이 아닌 일반 Join으로 쿼리가 나가는 이슈가 있었습니다.

그래서 이를 해결하기 위해 쿼리에 명시적으로 ElementCollection에 대해서도 명시적으로 Fetch Join을 걸어줬습니다.

이렇게 모든 문제가 끝나는 줄만 알았지만, 이번엔 Multiple bags exception이 발생하였습니다. 여기서 Bag이란 쉽게 말해서 List<>를 의미하는데 여러 개의 List<> fields에 대해서 동시에 Fetch하는 것이 금지되어 있어 발생하는 에러였습니다. 그래서 이를 해결하기 위해 저는 LinkedHashSet<>으로 변경하여 작업을 진행하였습니다.

그 결과 총 195개의 추가 쿼리가 발생했던 기존 로직에서 단 1개의 쿼리만 실행되도록 개선되었고 총 6.22초 걸리던 작업이 4.48초 정도로 줄면서 약 28%정도의 성능 향상을 꾀할 수 있었습니다.

이와 관련해서는 제 개인 기술 블로그에 매우 자세하게 기록해놓았습니다.

https://sungjindev.github.io/posts/n+1-issue/

## 📋 To Do

- 이번주 수요일에 있을 배포에 맞춰 배포 직전에 Develop To Main 릴리즈 진행할 예정입니다.
