### PR TITLE
가게 검색 API 개발 (#89)

### DIFF
--- a/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
@@ -96,9 +96,9 @@ public class StoreCertificationApi {
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, storeCertificationsByLocationRandomly);
     }
 
-    //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 75개의 가게 정보를 리턴
+    //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 30개의 가게 정보를 리턴
     @Tag(name = "가게 상세 정보")
-    @Operation(summary = "사용자 위치 및 검색어 기반 가게 상세 정보 제공", description = "현재 사용자의 위치 좌표와 검색 키워드를 전달받아 가게 DB에서 검색한 뒤, 사용자와 가까운 순으로 최대 75개의 가게 상세 정보를 반환해줍니다.<br><br>" +
+    @Operation(summary = "사용자 위치 및 검색어 기반 가게 상세 정보 제공", description = "현재 사용자의 위치 좌표와 검색 키워드를 전달받아 가게 DB에서 검색한 뒤, 사용자와 가까운 순으로 최대 30개의 가게 상세 정보를 반환해줍니다.<br><br>" +
             "[Request Body]<br>" +
             "currLong: 현재 사용자의 위치 좌표 경도값<br>" +
             "currLat: 현재 사용자의 위치 좌표 위도값<br>" +

--- a/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
@@ -117,7 +117,6 @@ public class StoreCertificationApi {
             "=> 각 인증제별 순서는 보장되지 않습니다.")
     @GetMapping("api/v1/storecertification/byLocationAndKeyword")
     public Result<List<StoreCertificationsByLocationResponse>> searchStoreCertificationsByLocationAndKeyword(@RequestParam("currLong") double currLong, @RequestParam("currLat") double currLat, @RequestParam("searchKeyword") String searchKeyword) {
-        System.out.println("API searchKeyword = " + searchKeyword);
         List<StoreCertificationsByLocationResponse> storeCertificationsByLocationAndKeyword = storeCertificationService.searchStoreCertificationsByLocationAndKeyword(currLong, currLat, searchKeyword);
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, storeCertificationsByLocationAndKeyword);
     }

--- a/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
@@ -117,7 +117,8 @@ public class StoreCertificationApi {
             "=> 각 인증제별 순서는 보장되지 않습니다.")
     @GetMapping("api/v1/storecertification/byLocationAndKeyword")
     public Result<List<StoreCertificationsByLocationResponse>> searchStoreCertificationsByLocationAndKeyword(@RequestParam("currLong") double currLong, @RequestParam("currLat") double currLat, @RequestParam("searchKeyword") String searchKeyword) {
-        List<StoreCertificationsByLocationResponse> storeCertificationsByLocationAndKeyword = storeCertificationService.searchStoreCertificationsByLocationAndKeyword(new Location(currLong, currLat), searchKeyword);
+        System.out.println("API searchKeyword = " + searchKeyword);
+        List<StoreCertificationsByLocationResponse> storeCertificationsByLocationAndKeyword = storeCertificationService.searchStoreCertificationsByLocationAndKeyword(currLong, currLat, searchKeyword);
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, storeCertificationsByLocationAndKeyword);
     }
 }

--- a/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
@@ -95,4 +95,29 @@ public class StoreCertificationApi {
         List<List<StoreCertificationsByLocationResponse>> storeCertificationsByLocationRandomly = storeCertificationService.findStoreCertificationsByLocationRandomly(new Location(nwLong, nwLat), new Location(swLong, swLat), new Location(seLong, seLat), new Location(neLong, neLat));
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, storeCertificationsByLocationRandomly);
     }
+
+    //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 75개의 가게 정보를 리턴
+    @Tag(name = "가게 상세 정보")
+    @Operation(summary = "사용자 위치 및 검색어 기반 가게 상세 정보 제공", description = "현재 사용자의 위치 좌표와 검색 키워드를 전달받아 가게 DB에서 검색한 뒤, 사용자와 가까운 순으로 최대 75개의 가게 상세 정보를 반환해줍니다.<br><br>" +
+            "[Request Body]<br>" +
+            "currLong: 현재 사용자의 위치 좌표 경도값<br>" +
+            "currLat: 현재 사용자의 위치 좌표 위도값<br>" +
+            "searchKeyword: 검색할 키워드<br><br>" +
+            "[Response Body]<br>" +
+            "id: Database 내 Primary Key값<br>" +
+            "displayName: 가게 이름<br>" +
+            "primaryTypeDisplayName: 업종<br>" +
+            "formattedAddress: 주소<br>" +
+            "phoneNumber: 전화번호<br>" +
+            "location: (경도, 위도) 가게 좌표<br>" +
+            "regularOpeningHours: 영업 시간<br>" +
+            "=> 특정 요일이 휴무인 경우에는 해당 요일에 대한 데이터가 들어있지 않습니다. Break time이 있는 경우 동일한 요일에 대해 영업 시간 데이터가 여러 개 존재할 수 있습니다. <br>" +
+            "localPhotos: 저장된 가게 사진 URL<br>" +
+            "certificationName: 가게의 인증제 목록<br>" +
+            "=> 각 인증제별 순서는 보장되지 않습니다.")
+    @GetMapping("api/v1/storecertification/byLocationAndKeyword")
+    public Result<List<StoreCertificationsByLocationResponse>> searchStoreCertificationsByLocationAndKeyword(@RequestParam("currLong") double currLong, @RequestParam("currLat") double currLat, @RequestParam("searchKeyword") String searchKeyword) {
+        List<StoreCertificationsByLocationResponse> storeCertificationsByLocationAndKeyword = storeCertificationService.searchStoreCertificationsByLocationAndKeyword(new Location(currLong, currLat), searchKeyword);
+        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, storeCertificationsByLocationAndKeyword);
+    }
 }

--- a/src/main/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationService.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationService.java
@@ -90,6 +90,37 @@ public class StoreCertificationService {
         return storeCertificationsByLocationListResponses;
     }
 
+    //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 75개의 가게 정보를 리턴
+    //단 이 로직은 UX를 고려해서 총 75개의 가게를 15개씩 쪼개서 5회차로 나누어 보내는 로직은 구현하지 않기로 결정
+    public List<StoreCertificationsByLocationResponse> searchStoreCertificationsByLocationAndKeyword(Location currentLocation, String searchKeyword) {
+        List<StoreCertification> storeCertificationsByLocation = storeCertificationRepository.searchStoreCertificationsByLocationAndKeyword(currentLocation, searchKeyword);
+        List<StoreCertificationsByLocationResponse> storeCertificationsByLocationResponses = new ArrayList<>(); //반환해줄 StoreCertificationsByLocationResponse들의 List
+
+        Map<Long, Boolean> isChecked = new HashMap<>(); //이미 조회한 가게인지 여부를 저장하는 HashMap
+
+        for (StoreCertification storeCertification : storeCertificationsByLocation) {
+            if (!duplicatedStoreIds.contains(storeCertification.getStore().getId())) {
+                storeCertificationsByLocationResponses.add(new StoreCertificationsByLocationResponse(storeCertification));
+            } else {
+                Boolean result = isChecked.get(storeCertification.getStore().getId());
+                if (result == null) {
+                    StoreCertificationsByLocationResponse storeCertificationsByLocationResponse = new StoreCertificationsByLocationResponse(storeCertification);
+
+                    List<StoreCertification> storeCertificationsByStoreId = storeCertificationRepository.findStoreCertificationsByStoreId(storeCertification.getStore().getId());
+                    for (StoreCertification storeCertificationByStoreId : storeCertificationsByStoreId) {   //위에서 이미 추가해준 인증제 이름일 경우 제외
+                        if(!storeCertificationByStoreId.getCertification().getName().equals(storeCertification.getCertification().getName()))
+                            storeCertificationsByLocationResponse.getCertificationName().add(storeCertificationByStoreId.getCertification().getName());
+                    }
+
+                    storeCertificationsByLocationResponses.add(storeCertificationsByLocationResponse);
+                    isChecked.put(storeCertification.getStore().getId(), true); //체크되었다고 기록
+                }
+            }
+        }
+
+        return storeCertificationsByLocationResponses;
+    }
+
     public List<Long> getDuplicatedStoreIds() {
         return duplicatedStoreIds;
     }

--- a/src/main/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationService.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationService.java
@@ -94,7 +94,6 @@ public class StoreCertificationService {
     //단 이 로직은 UX를 고려해서 총 75개의 가게를 15개씩 쪼개서 5회차로 나누어 보내는 로직은 구현하지 않기로 결정
     public List<StoreCertificationsByLocationResponse> searchStoreCertificationsByLocationAndKeyword(Double currLong, Double currLat, String searchKeyword) {
         List<StoreCertification> storeCertificationsByLocation = storeCertificationRepository.searchStoreCertificationsByLocationAndKeyword(currLong, currLat, searchKeyword);
-        System.out.println("storeCertificationsByLocation.size() = " + storeCertificationsByLocation.size());
         List<StoreCertificationsByLocationResponse> storeCertificationsByLocationResponses = new ArrayList<>(); //반환해줄 StoreCertificationsByLocationResponse들의 List
 
         Map<Long, Boolean> isChecked = new HashMap<>(); //이미 조회한 가게인지 여부를 저장하는 HashMap
@@ -119,7 +118,16 @@ public class StoreCertificationService {
             }
         }
 
-        return storeCertificationsByLocationResponses;
+        List<StoreCertificationsByLocationResponse> storeCertificationsByLocationListResponses = new ArrayList<>();
+
+        for(int i=1; i <= storeCertificationsByLocationResponses.size(); ++i) {
+            storeCertificationsByLocationListResponses.add(storeCertificationsByLocationResponses.get(i-1));
+            if (i == 75 || i == storeCertificationsByLocationResponses.size()) { //요구사항에 따른 가게 최대 개수가 75개 이므로, 0부터 74까지만!
+                break;
+            }
+        }
+
+        return storeCertificationsByLocationListResponses;
     }
 
     public List<Long> getDuplicatedStoreIds() {

--- a/src/main/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationService.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationService.java
@@ -92,8 +92,9 @@ public class StoreCertificationService {
 
     //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 75개의 가게 정보를 리턴
     //단 이 로직은 UX를 고려해서 총 75개의 가게를 15개씩 쪼개서 5회차로 나누어 보내는 로직은 구현하지 않기로 결정
-    public List<StoreCertificationsByLocationResponse> searchStoreCertificationsByLocationAndKeyword(Location currentLocation, String searchKeyword) {
-        List<StoreCertification> storeCertificationsByLocation = storeCertificationRepository.searchStoreCertificationsByLocationAndKeyword(currentLocation, searchKeyword);
+    public List<StoreCertificationsByLocationResponse> searchStoreCertificationsByLocationAndKeyword(Double currLong, Double currLat, String searchKeyword) {
+        List<StoreCertification> storeCertificationsByLocation = storeCertificationRepository.searchStoreCertificationsByLocationAndKeyword(currLong, currLat, searchKeyword);
+        System.out.println("storeCertificationsByLocation.size() = " + storeCertificationsByLocation.size());
         List<StoreCertificationsByLocationResponse> storeCertificationsByLocationResponses = new ArrayList<>(); //반환해줄 StoreCertificationsByLocationResponse들의 List
 
         Map<Long, Boolean> isChecked = new HashMap<>(); //이미 조회한 가게인지 여부를 저장하는 HashMap

--- a/src/main/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationService.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/application/StoreCertificationService.java
@@ -90,8 +90,8 @@ public class StoreCertificationService {
         return storeCertificationsByLocationListResponses;
     }
 
-    //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 75개의 가게 정보를 리턴
-    //단 이 로직은 UX를 고려해서 총 75개의 가게를 15개씩 쪼개서 5회차로 나누어 보내는 로직은 구현하지 않기로 결정
+    //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 30개의 가게 정보를 리턴
+    //단 이 로직은 UX를 고려해서 총 30개의 가게를 15개씩 쪼개서 5회차로 나누어 보내는 로직은 구현하지 않기로 결정
     public List<StoreCertificationsByLocationResponse> searchStoreCertificationsByLocationAndKeyword(Double currLong, Double currLat, String searchKeyword) {
         List<StoreCertification> storeCertificationsByLocation = storeCertificationRepository.searchStoreCertificationsByLocationAndKeyword(currLong, currLat, searchKeyword);
         List<StoreCertificationsByLocationResponse> storeCertificationsByLocationResponses = new ArrayList<>(); //반환해줄 StoreCertificationsByLocationResponse들의 List
@@ -122,7 +122,7 @@ public class StoreCertificationService {
 
         for(int i=1; i <= storeCertificationsByLocationResponses.size(); ++i) {
             storeCertificationsByLocationListResponses.add(storeCertificationsByLocationResponses.get(i-1));
-            if (i == 75 || i == storeCertificationsByLocationResponses.size()) { //요구사항에 따른 가게 최대 개수가 75개 이므로, 0부터 74까지만!
+            if (i == 30 || i == storeCertificationsByLocationResponses.size()) { //요구사항에 따른 가게 최대 개수가 30개 이므로, 1부터 30까지만!
                 break;
             }
         }

--- a/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
@@ -80,7 +80,7 @@ public class StoreCertificationRepository {
     }
 
     //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 75개의 가게 정보를 리턴
-    public List<StoreCertification> searchStoreCertificationsByLocation(Location currentLocation, String searchKeyword) { //사용자의 현재 (경도, 위도) 좌표와 검색 키워드를 전달 받기
+    public List<StoreCertification> searchStoreCertificationsByLocationAndKeyword(Location currentLocation, String searchKeyword) { //사용자의 현재 (경도, 위도) 좌표와 검색 키워드를 전달 받기
         TypedQuery<StoreCertification> query = em.createQuery(
                 "SELECT sc FROM StoreCertification sc " +
                         "JOIN FETCH sc.store s " +

--- a/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
@@ -78,5 +78,21 @@ public class StoreCertificationRepository {
 
         return query.getResultList();
     }
+
+    //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 75개의 가게 정보를 리턴
+    public List<StoreCertification> searchStoreCertificationsByLocation(Location currentLocation, String searchKeyword) { //사용자의 현재 (경도, 위도) 좌표와 검색 키워드를 전달 받기
+        TypedQuery<StoreCertification> query = em.createQuery(
+                "SELECT sc FROM StoreCertification sc " +
+                        "JOIN FETCH sc.store s " +
+                        "JOIN FETCH sc.certification c " +
+                        "WHERE sc.store.displayName LIKE CONCAT('%', :searchKeyword, '%') " +   //가게 이름에 대한 검색
+                        "OR sc.store.primaryTypeDisplayName LIKE CONCAT('%', :searchKeyword, '%') " +   //업종에 대한 검색
+                        "OR sc.store.formattedAddress LIKE CONCAT('%', :searchKeyword, '%') " + //주소에 대한 검색
+                        "ORDER BY (6371 * acos(cos(radians(36.628486474734)) * cos(radians(ST_Y(:currentLocation))) * cos(radians(ST_X(:currentLocation)) - radians(127.4574415007155)) + sin(radians(36.628486474734)) * sin(radians(ST_Y(:currentLocation))))) LIMIT 75", //하버사인 공식을 이용해 두 좌표상 거리 구하기
+                StoreCertification.class).setParameter("currentLocation", currentLocation)
+                .setParameter("searchKeyword", searchKeyword);
+
+        return query.getResultList();
+    }
 }
 

--- a/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
@@ -81,7 +81,6 @@ public class StoreCertificationRepository {
 
     //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 75개의 가게 정보를 리턴
     public List<StoreCertification> searchStoreCertificationsByLocationAndKeyword(Double currLong, Double currLat, String searchKeyword) {
-        System.out.println("searchKeyword = " + searchKeyword);
         String nativeQuery = "SELECT sc.* FROM store_certification sc " +
                 "JOIN store AS s ON sc.store_id = s.store_id " +
                 "JOIN certification AS c ON sc.certification_id = c.certification_id " +

--- a/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/dao/StoreCertificationRepository.java
@@ -79,7 +79,7 @@ public class StoreCertificationRepository {
         return query.getResultList();
     }
 
-    //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 75개의 가게 정보를 리턴
+    //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 30개의 가게 정보를 리턴
     public List<StoreCertification> searchStoreCertificationsByLocationAndKeyword(Double currLong, Double currLat, String searchKeyword) {
         String nativeQuery = "SELECT sc.* FROM store_certification sc " +
                 "JOIN store AS s ON sc.store_id = s.store_id " +
@@ -87,7 +87,7 @@ public class StoreCertificationRepository {
                 "WHERE s.display_name LIKE :searchKeyword " +
                 "OR s.primary_type_display_name LIKE :searchKeyword " +
                 "OR s.formatted_address LIKE :searchKeyword " +
-                "ORDER BY (6371 * acos(cos(radians(:currLat)) * cos(radians(ST_Y(s.location))) * cos(radians(ST_X(s.location)) - radians(:currLong)) + sin(radians(:currLat)) * sin(radians(ST_Y(s.location))))) limit 225";    //세 인증제를 모두 가지고 있는 가게가 있으므로 3 * 75 = 225
+                "ORDER BY (6371 * acos(cos(radians(:currLat)) * cos(radians(ST_Y(s.location))) * cos(radians(ST_X(s.location)) - radians(:currLong)) + sin(radians(:currLat)) * sin(radians(ST_Y(s.location))))) limit 90";    //세 인증제를 모두 가지고 있는 가게가 있으므로 3 * 30 = 90
 
         Query query = em.createNativeQuery(nativeQuery, StoreCertification.class)
                 .setParameter("currLong", currLong)


### PR DESCRIPTION
## ⭐️ Issue Number

- #89 

## 🚩 Summary
사용자가 텍스트 키워드를 통해 가게 DB에서 가게를 검색할 수 있도록 해주는 가게 검색 API를 개발합니다.

해당 API에대한 간단한 API 명세는 다음과 같습니다.
1. 가게 이름, 업종, 주소에 대해 텍스트 대치 형식으로 가게 DB에서 검색합니다.
2. 클라이언트로부터 사용자의 현재 (경도, 위도) 위치 좌표를 받고 해당 좌표에서 가장 가까운 순으로 검색 결과를 뽑습니다.
3. 검색 결과는 사용자와 가까운 순으로 최대 30개까지만 반환합니다.

## 🛠️ Technical Concerns

### 지구 상 두 점에서 (경도, 위도) 좌표로 거리 계산 (하버사인 공식)

평면 상에서 두 점의 거리를 구하는 것이야 굉장히 간단하지만 저희가 사용하고 있는 (경도, 위도) 좌표는 거의 구에 가까운 지구 면에 존재하는 좌표계이기때문에 별도의 계산 방법이 필요했습니다.

그래서 관련해서 검색하던 중 하버사인 공식이라는 것이 있었고 이를 이용하면 (경도, 위도) 두 좌표 간의 구면 거리를 쉽게 계산할 수 있었습니다.

```java
        String nativeQuery = "SELECT sc.* FROM store_certification sc " +
                "JOIN store AS s ON sc.store_id = s.store_id " +
                "JOIN certification AS c ON sc.certification_id = c.certification_id " +
                "WHERE s.display_name LIKE :searchKeyword " +
                "OR s.primary_type_display_name LIKE :searchKeyword " +
                "OR s.formatted_address LIKE :searchKeyword " +
                "ORDER BY (6371 * acos(cos(radians(:currLat)) * cos(radians(ST_Y(s.location))) * cos(radians(ST_X(s.location)) - radians(:currLong)) + sin(radians(:currLat)) * sin(radians(ST_Y(s.location))))) limit 90";    //세 인증제를 모두 가지고 있는 가게가 있으므로 3 * 30 = 90
```

제가 작성한 쿼리는 위와 같고 하버사인 공식은 ORDER BY 부분에 저장되어 있습니다.
사용자로부터 현재 위치 (경도, 위도) 좌표를 받고 이를 저희 가게 DB의 가게들과 거리를 재면서 거리에 따라 오름차순으로 정렬합니다.
그 후 총 90개의 가게 정보들을 JOIN해서 가져옵니다.

여기서 요구 사항에 필요한 최대 가게는 30개임에도 불구하고 limit를 90으로 설정해놓은 이유는 현재 조회하고 있는 테이블이 StoreCertification 테이블이고 이 테이블에는 같은 가게이지만 서로 다른 인증제를 가지면 별도의 Row로 저장되므로 이에 대한 Worst case를 고려하여 모든 가게가 최대 인증제 개수인 3개씩 가지고 있을 수 있기 때문에 30 * 3으로 설정해뒀습니다.

처음에 위 로직을 JPQL을 사용해서 작성했었지만 radians() 안에 POINT 타입에서 위도, 경도를 추출해주는 ST_X, ST_Y가 잘 적용되지 않아서 네이티브 쿼리로 변경하였습니다.

아무래도 JPQL은 표준 SQL을 확장한 것이고 데이터베이스에 종속적인 쿼리 작성을 지양하기 때문에 MySQL 공간데이터 함수와 같은 MySQL에 specific한 기능들이 잘 적용되지 않았습니다. 

## 📋 To Do

- 검색어 자동 완성 기능에 대한 공부와 구현
