### PR TITLE
API Versioning 방식 변경 (#93)

### DIFF
--- a/src/main/java/com/nainga/nainga/domain/store/api/StoreApi.java
+++ b/src/main/java/com/nainga/nainga/domain/store/api/StoreApi.java
@@ -25,7 +25,7 @@ public class StoreApi {
     @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "모범음식점 데이터 생성", description = "[WARNING] DB에 처음으로 모든 모범음식점 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
-    @GetMapping("api/v1/store/mobeom")
+    @GetMapping("api/store/mobeom/v1")
     public Result<String> createAllMobeomStores(@RequestParam(value = "fileName") String fileName) {
         mobeomGoogleMapStoreService.createAllMobeomStores(fileName);
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, null);
@@ -34,7 +34,7 @@ public class StoreApi {
     @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "지정한 Credit까지만 사용하여 모범음식점 데이터 생성", description = "[WARNING] 지정한 Credit까지만 사용하여 그동안 DB에 모범음식점 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
-    @GetMapping("api/v1/store/dividedMobeom")
+    @GetMapping("api/store/dividedMobeom/v1")
     public Result<CreateDividedMobeomStoresResponse> createDividedMobeomStores(@RequestParam(value = "fileName") String fileName, @RequestParam(value = "dollars") double dollars, @RequestParam(value = "startIndex") int startIndex) {
         CreateDividedMobeomStoresResponse response = mobeomGoogleMapStoreService.createDividedMobeomStores(fileName, dollars, startIndex);
         System.out.println("response = " + response);   //편하게 콘솔 로그에서 확인하기 위한 용도
@@ -44,7 +44,7 @@ public class StoreApi {
     @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "안심식당 데이터 생성", description = "[WARNING] DB에 처음으로 모든 안심식당 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
-    @GetMapping("api/v1/store/safe")
+    @GetMapping("api/store/safe/v1")
     public Result<String> createAllSafeStores(@RequestParam(value = "fileName") String fileName) {
         safeGoogleMapStoreService.createAllSafeStores(fileName);
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, null);
@@ -53,7 +53,7 @@ public class StoreApi {
     @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "지정한 Credit까지만 사용하여 안심식당 데이터 생성", description = "[WARNING] 지정한 Credit까지만 사용하여 그동안 DB에 안심식당 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
-    @GetMapping("api/v1/store/dividedSafe")
+    @GetMapping("api/store/dividedSafe/v1")
     public Result<CreateDividedSafeStoresResponse> createDividedSafeStores(@RequestParam(value = "fileName") String fileName, @RequestParam(value = "dollars") double dollars, @RequestParam(value = "startIndex") int startIndex) {
         CreateDividedSafeStoresResponse response = safeGoogleMapStoreService.createDividedSafeStores(fileName, dollars, startIndex);
         System.out.println("response = " + response);   //편하게 콘솔 로그에서 확인하기 위한 용도
@@ -63,7 +63,7 @@ public class StoreApi {
     @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "착한가격업소 데이터 생성", description = "[WARNING] DB에 처음으로 모든 착한가격업소 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
-    @GetMapping("api/v1/store/goodPrice")
+    @GetMapping("api/store/goodPrice/v1")
     public Result<String> createAllGoodPriceStores(@RequestParam(value = "fileName") String fileName) {
         goodPriceGoogleMapStoreService.createAllGoodPriceStores(fileName);
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, null);
@@ -72,7 +72,7 @@ public class StoreApi {
     @Hidden
     @Tag(name = "초기 Data 생성")
     @Operation(summary = "지정한 Credit까지만 사용하여 착한가격업소 데이터 생성", description = "[WARNING] 지정한 Credit까지만 사용하여 그동안 DB에 착한가격업소 데이터를 주입해주는 API입니다. DB에 엄청난 부하가 가는 작업으로, 합의 없이 실행시켜선 안됩니다!")
-    @GetMapping("api/v1/store/dividedGoodPrice")
+    @GetMapping("api/store/dividedGoodPrice/v1")
     public Result<CreateDividedGoodPriceStoresResponse> createDividedGoodPriceStores(@RequestParam(value = "fileName") String fileName, @RequestParam(value = "dollars") double dollars, @RequestParam(value = "startIndex") int startIndex) {
         CreateDividedGoodPriceStoresResponse response = goodPriceGoogleMapStoreService.createDividedGoodPriceStores(fileName, dollars, startIndex);
         System.out.println("response = " + response);   //편하게 콘솔 로그에서 확인하기 위한 용도

--- a/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
+++ b/src/main/java/com/nainga/nainga/domain/storecertification/api/StoreCertificationApi.java
@@ -24,7 +24,7 @@ public class StoreCertificationApi {
     private final StoreCertificationService storeCertificationService;
 
     //총 사각형 영역의 네 꼭짓점 좌표를 받아, 해당 가게들의 상세 정보를 반환
-    @Tag(name = "가게 상세 정보")
+    @Tag(name = "[Legacy] 가게 상세 정보")
     @Operation(summary = "사용자 위치 기반 가게 상세 정보 제공 V1", description = "총 사각형 영역의 네 꼭짓점 좌표를 받아 해당 가게들의 상세 정보를 반환해줍니다.<br><br>" +
             "[Request Body]<br>" +
             "nwLong: 북서쪽 좌표 경도<br>" +
@@ -44,7 +44,7 @@ public class StoreCertificationApi {
             "certificationName: 가게의 인증제 목록<br>" +
             "=> 각 인증제별 순서는 보장되지 않습니다.")
     @GetMapping("api/v1/storecertification/byLocation")
-    public Result<List<StoreCertificationsByLocationResponse>> findStoreCertificationsByLocation(@RequestParam("nwLong") double nwLong, @RequestParam("nwLat") double nwLat, @RequestParam("swLong") double swLong, @RequestParam("swLat") double swLat, @RequestParam("seLong") double seLong, @RequestParam("seLat") double seLat, @RequestParam("neLong") double neLong, @RequestParam("neLat") double neLat) {
+    public Result<List<StoreCertificationsByLocationResponse>> findStoreCertificationsByLocationLegacy(@RequestParam("nwLong") double nwLong, @RequestParam("nwLat") double nwLat, @RequestParam("swLong") double swLong, @RequestParam("swLat") double swLat, @RequestParam("seLong") double seLong, @RequestParam("seLat") double seLat, @RequestParam("neLong") double neLong, @RequestParam("neLat") double neLat) {
         List<StoreCertification> storeCertificationsByLocation = storeCertificationService.findStoreCertificationsByLocation(new Location(nwLong, nwLat), new Location(swLong, swLat), new Location(seLong, seLat), new Location(neLong, neLat));
         List<Long> storeIdsWithMultipleCertifications = storeCertificationService.getDuplicatedStoreIds(); //여러 인증제를 가지고 있는 가게의 id 리스트
         List<StoreCertificationsByLocationResponse> storeCertificationsByLocationResponses = new ArrayList<>(); //반환해줄 StoreCertificationsByLocationResponse들의 List
@@ -71,7 +71,7 @@ public class StoreCertificationApi {
     }
 
     //총 사각형 영역의 네 꼭짓점 좌표를 받아 최대 75개를 랜덤하게 뽑아낸 뒤, 해당 가게들의 상세 정보를 반환
-    @Tag(name = "가게 상세 정보")
+    @Tag(name = "[Legacy] 가게 상세 정보")
     @Operation(summary = "사용자 위치 기반 가게 상세 정보 제공 V2", description = "총 사각형 영역의 네 꼭짓점 좌표를 받아 최대 75개를 랜덤하게 뽑아낸 뒤, 해당 가게들의 상세 정보를 반환해줍니다.<br><br>" +
             "[Request Body]<br>" +
             "nwLong: 북서쪽 좌표 경도<br>" +
@@ -91,13 +91,13 @@ public class StoreCertificationApi {
             "certificationName: 가게의 인증제 목록<br>" +
             "=> 각 인증제별 순서는 보장되지 않습니다.")
     @GetMapping("api/v2/storecertification/byLocation")
-    public Result<List<List<StoreCertificationsByLocationResponse>>> findStoreCertificationsByLocationRandomly(@RequestParam("nwLong") double nwLong, @RequestParam("nwLat") double nwLat, @RequestParam("swLong") double swLong, @RequestParam("swLat") double swLat, @RequestParam("seLong") double seLong, @RequestParam("seLat") double seLat, @RequestParam("neLong") double neLong, @RequestParam("neLat") double neLat) {
+    public Result<List<List<StoreCertificationsByLocationResponse>>> findStoreCertificationsByLocationRandomlyLegacy(@RequestParam("nwLong") double nwLong, @RequestParam("nwLat") double nwLat, @RequestParam("swLong") double swLong, @RequestParam("swLat") double swLat, @RequestParam("seLong") double seLong, @RequestParam("seLat") double seLat, @RequestParam("neLong") double neLong, @RequestParam("neLat") double neLat) {
         List<List<StoreCertificationsByLocationResponse>> storeCertificationsByLocationRandomly = storeCertificationService.findStoreCertificationsByLocationRandomly(new Location(nwLong, nwLat), new Location(swLong, swLat), new Location(seLong, seLat), new Location(neLong, neLat));
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, storeCertificationsByLocationRandomly);
     }
 
     //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 30개의 가게 정보를 리턴
-    @Tag(name = "가게 상세 정보")
+    @Tag(name = "[Legacy] 가게 상세 정보")
     @Operation(summary = "사용자 위치 및 검색어 기반 가게 상세 정보 제공", description = "현재 사용자의 위치 좌표와 검색 키워드를 전달받아 가게 DB에서 검색한 뒤, 사용자와 가까운 순으로 최대 30개의 가게 상세 정보를 반환해줍니다.<br><br>" +
             "[Request Body]<br>" +
             "currLong: 현재 사용자의 위치 좌표 경도값<br>" +
@@ -116,8 +116,65 @@ public class StoreCertificationApi {
             "certificationName: 가게의 인증제 목록<br>" +
             "=> 각 인증제별 순서는 보장되지 않습니다.")
     @GetMapping("api/v1/storecertification/byLocationAndKeyword")
+    public Result<List<StoreCertificationsByLocationResponse>> searchStoreCertificationsByLocationAndKeywordLegacy(@RequestParam("currLong") double currLong, @RequestParam("currLat") double currLat, @RequestParam("searchKeyword") String searchKeyword) {
+        List<StoreCertificationsByLocationResponse> storeCertificationsByLocationAndKeyword = storeCertificationService.searchStoreCertificationsByLocationAndKeyword(currLong, currLat, searchKeyword);
+        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, storeCertificationsByLocationAndKeyword);
+    }
+
+    /*
+        이 이하로는 모두 새로운 API Versioning 적용! Version이 URI에서 제일 뒤에 가도록 변경하였습니다.
+        한 동안은 전 API Versioning 방식과 후 API Versioning 방식 모두 유지시키고 나중에는 최근 API Versioning 방식만 남겨둘 계획입니다.
+     */
+
+    //총 사각형 영역의 네 꼭짓점 좌표를 받아 최대 75개를 랜덤하게 뽑아낸 뒤, 해당 가게들의 상세 정보를 반환
+    @Tag(name = "[New] 가게 상세 정보")
+    @Operation(summary = "사용자 위치 기반 가게 상세 정보 제공 V2", description = "총 사각형 영역의 네 꼭짓점 좌표를 받아 최대 75개를 랜덤하게 뽑아낸 뒤, 해당 가게들의 상세 정보를 반환해줍니다.<br><br>" +
+            "[Request Body]<br>" +
+            "nwLong: 북서쪽 좌표 경도<br>" +
+            "nwLat: 북서쪽 좌표 위도<br>" +
+            "seLong: 남동쪽 좌표 경도<br>" +
+            "seLat: 남동쪽 좌표 위도<br><br>" +
+            "[Response Body]<br>" +
+            "id: Database 내 Primary Key값<br>" +
+            "displayName: 가게 이름<br>" +
+            "primaryTypeDisplayName: 업종<br>" +
+            "formattedAddress: 주소<br>" +
+            "phoneNumber: 전화번호<br>" +
+            "location: (경도, 위도) 가게 좌표<br>" +
+            "regularOpeningHours: 영업 시간<br>" +
+            "=> 특정 요일이 휴무인 경우에는 해당 요일에 대한 데이터가 들어있지 않습니다. Break time이 있는 경우 동일한 요일에 대해 영업 시간 데이터가 여러 개 존재할 수 있습니다. <br>" +
+            "localPhotos: 저장된 가게 사진 URL<br>" +
+            "certificationName: 가게의 인증제 목록<br>" +
+            "=> 각 인증제별 순서는 보장되지 않습니다.")
+    @GetMapping("api/storecertification/byLocation/v2")
+    public Result<List<List<StoreCertificationsByLocationResponse>>> findStoreCertificationsByLocationRandomly(@RequestParam("nwLong") double nwLong, @RequestParam("nwLat") double nwLat, @RequestParam("swLong") double swLong, @RequestParam("swLat") double swLat, @RequestParam("seLong") double seLong, @RequestParam("seLat") double seLat, @RequestParam("neLong") double neLong, @RequestParam("neLat") double neLat) {
+        List<List<StoreCertificationsByLocationResponse>> storeCertificationsByLocationRandomly = storeCertificationService.findStoreCertificationsByLocationRandomly(new Location(nwLong, nwLat), new Location(swLong, swLat), new Location(seLong, seLat), new Location(neLong, neLat));
+        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, storeCertificationsByLocationRandomly);
+    }
+
+    //검색어를 이용해 가게 이름, 업종, 주소에 대해 검색하고 나온 검색 결과 중 사용자로부터 가까운 순으로 최대 30개의 가게 정보를 리턴
+    @Tag(name = "[New] 가게 상세 정보")
+    @Operation(summary = "사용자 위치 및 검색어 기반 가게 상세 정보 제공", description = "현재 사용자의 위치 좌표와 검색 키워드를 전달받아 가게 DB에서 검색한 뒤, 사용자와 가까운 순으로 최대 30개의 가게 상세 정보를 반환해줍니다.<br><br>" +
+            "[Request Body]<br>" +
+            "currLong: 현재 사용자의 위치 좌표 경도값<br>" +
+            "currLat: 현재 사용자의 위치 좌표 위도값<br>" +
+            "searchKeyword: 검색할 키워드<br><br>" +
+            "[Response Body]<br>" +
+            "id: Database 내 Primary Key값<br>" +
+            "displayName: 가게 이름<br>" +
+            "primaryTypeDisplayName: 업종<br>" +
+            "formattedAddress: 주소<br>" +
+            "phoneNumber: 전화번호<br>" +
+            "location: (경도, 위도) 가게 좌표<br>" +
+            "regularOpeningHours: 영업 시간<br>" +
+            "=> 특정 요일이 휴무인 경우에는 해당 요일에 대한 데이터가 들어있지 않습니다. Break time이 있는 경우 동일한 요일에 대해 영업 시간 데이터가 여러 개 존재할 수 있습니다. <br>" +
+            "localPhotos: 저장된 가게 사진 URL<br>" +
+            "certificationName: 가게의 인증제 목록<br>" +
+            "=> 각 인증제별 순서는 보장되지 않습니다.")
+    @GetMapping("api/storecertification/byLocationAndKeyword/v1")
     public Result<List<StoreCertificationsByLocationResponse>> searchStoreCertificationsByLocationAndKeyword(@RequestParam("currLong") double currLong, @RequestParam("currLat") double currLat, @RequestParam("searchKeyword") String searchKeyword) {
         List<StoreCertificationsByLocationResponse> storeCertificationsByLocationAndKeyword = storeCertificationService.searchStoreCertificationsByLocationAndKeyword(currLong, currLat, searchKeyword);
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, storeCertificationsByLocationAndKeyword);
     }
+
 }

--- a/src/main/java/com/nainga/nainga/global/config/SwaggerConfig.java
+++ b/src/main/java/com/nainga/nainga/global/config/SwaggerConfig.java
@@ -32,7 +32,7 @@ public class SwaggerConfig {
                                                 "참고로 Swagger 상에서는 Base URL이 달라 테스트가 불가능합니다.<br>" +
                                                 "만약 테스트를 원하신다면 브라우저 상에서 직접 URL을 입력해주시면 됩니다.<br>" +
                                                 "예) https://storage.googleapis.com/kcs-dev-bucket1/ad06294c-d4ed-42bd-9839-82af8714bd1e")
-                                .tags(List.of("가게 상세 정보"))
+                                .tags(List.of("[New] 가게 상세 정보"))
                                 .responses(new ApiResponses().addApiResponse("200",
                                         new ApiResponse().description("OK")
                                                 .content(new Content().addMediaType("image/jpeg", new MediaType()


### PR DESCRIPTION
## ⭐️ Issue Number

- #93 

## 🚩 Summary
현재 API Versioning을 위해서 URI Versioning 방식을 사용하고 있습니다.
최근 클라이언트 단의 요청에 따라 Version과 관련된 Path가 더 뒤에 배치되는 것이 관리하기가 좋다는 피드백이 들어와 앞으로 배포되는 API는 모두 해당 방식으로 구현할 예정이며 기존에 이미 존재하는 API들은 운영에 이슈가 생기지 않도록 당분간은 API Versioning 두 가지 방식을 모두 채택하여 구현해놓으려고 합니다. 참고로 아래는 현 방식과 앞으로 바꾸게되는 방식 예시입니다.

[현 방식]
/api/v1/findStores/byLocation

[바꿀 방식]
/api/findStores/byLocation/v1

- [x] 기존에 존재하던 API들을 유지함과 동시에 새로운 Versioning 방식의 API들도 만들기

## 🛠️ Technical Concerns

### API Versioning 방식에 대한 고민
먼저 클라이언트 개발 측으로부터 API Versioning path의 위치를 조정해줬으면 좋겠다라는 의견이 있었고 그 후 어떤 방식의 Versioning을 취하는 것이 가장 이점이 많을지 고민하였습니다.

API Versioning 관련해서 크게 4가지 방법이 있었습니다.
1. URI 방식
2. Query Request Parameter 방식
3. Custom Header 방식
4. MIME type 방식

그 중에서도 저희는 이미 V3.0.0 애플리케이션을 운영중이고 이전 버전에 대한 사용자들이 존재한다는 점, 아직 클라이언트 단에서 Deprecated될 버전을 사용하고 있는 사용자들에게 업데이트를 강제하는 로직을 구현하지 못했다는 점 등을 고려해서 최대한 변경 요소를 줄이기 위해 기존에 사용하던 URI 방식을 클라이언트 측의 요구 및 필요에 맞게 변경하기로 결정하였습니다.

## 📋 To Do

- 검색어 자동 완성 기능에 대한 공부와 구현